### PR TITLE
Remove void_t, invoke and similar symbols

### DIFF
--- a/data/doxygen.h
+++ b/data/doxygen.h
@@ -365,13 +365,7 @@ namespace gul17 {
  * <dd>Copyright 2018 Tristan Brindle.
  *     Distributed under the Boost Software License, Version 1.0 (see
  *     \ref license_boost_1_0 and \ref span.h for details).</dd>
- *
- * <dt>\ref traits.h</dt>
- * <dd>Copyright 2015-2017 Michael Park (implementations of invoke, invoke_result,
- *     invoke_result_t, is_invocable, is_invocable_r), copyright 2021-2024 Deutsches
- *     Elektronen-Synchrotron (DESY), Hamburg (other implementations and modifications).
- *     Distributed under the Boost Software License, Version 1.0 (see
- *     \ref license_boost_1_0 and \ref traits.h for details).</dd>
+ * </dl>
  */
 
 /**

--- a/debian/copyright.in
+++ b/debian/copyright.in
@@ -29,11 +29,6 @@ Copyright: 2018 Tristan Brindle
            2019 libgul contributors (L. Fröhlich)
 License: BSL-1.0
 
-Files: include/gul17/traits.h
-Copyright: 2015-2017 Michael Park
-           2021-2024 libgul contributors (L. Fröhlich, U.F. Jastrow)
-License: BSL-1.0
-
 License: LGPL-2.1+
  This package is free software; you can redistribute it and/or
  modify it under the terms of the GNU Lesser General Public

--- a/include/gul17/ThreadPool.h
+++ b/include/gul17/ThreadPool.h
@@ -301,15 +301,15 @@ public:
      *        objects
      */
     template <typename Function>
-    TaskHandle<invoke_result_t<Function, ThreadPool&>>
+    TaskHandle<std::invoke_result_t<Function, ThreadPool&>>
     add_task(Function fct, TimePoint start_time = {}, std::string name = {})
     {
         static_assert(
-            is_invocable<Function, ThreadPool&>::value
-            || is_invocable<Function>::value,
+            std::is_invocable<Function, ThreadPool&>::value
+            || std::is_invocable<Function>::value,
             "Invalid function signature: Must be T fct() or T fct(ThreadPool&)");
 
-        using Result = invoke_result_t<Function, ThreadPool&>;
+        using Result = std::invoke_result_t<Function, ThreadPool&>;
 
         TaskHandle<Result> task_handle = [this, &fct, start_time, &name]()
             {
@@ -344,8 +344,8 @@ public:
     }
 
     template <typename Function,
-        std::enable_if_t<is_invocable<Function>::value, bool> = true>
-    TaskHandle<invoke_result_t<Function>>
+        std::enable_if_t<std::is_invocable<Function>::value, bool> = true>
+    TaskHandle<std::invoke_result_t<Function>>
     add_task(Function fct, TimePoint start_time = {}, std::string name = {})
     {
         return add_task(
@@ -354,8 +354,8 @@ public:
     }
 
     template <typename Function,
-        std::enable_if_t<is_invocable<Function, ThreadPool&>::value, bool> = true>
-    TaskHandle<invoke_result_t<Function, ThreadPool&>>
+        std::enable_if_t<std::is_invocable<Function, ThreadPool&>::value, bool> = true>
+    TaskHandle<std::invoke_result_t<Function, ThreadPool&>>
     add_task(Function fct, Duration delay_before_start, std::string name = {})
     {
         return add_task(std::move(fct),
@@ -363,8 +363,8 @@ public:
     }
 
     template <typename Function,
-        std::enable_if_t<is_invocable<Function>::value, bool> = true>
-    TaskHandle<invoke_result_t<Function>>
+        std::enable_if_t<std::is_invocable<Function>::value, bool> = true>
+    TaskHandle<std::invoke_result_t<Function>>
     add_task(Function fct, Duration delay_before_start, std::string name = {})
     {
         return add_task(std::move(fct),
@@ -372,16 +372,16 @@ public:
     }
 
     template <typename Function,
-        std::enable_if_t<is_invocable<Function, ThreadPool&>::value, bool> = true>
-    TaskHandle<invoke_result_t<Function, ThreadPool&>>
+        std::enable_if_t<std::is_invocable<Function, ThreadPool&>::value, bool> = true>
+    TaskHandle<std::invoke_result_t<Function, ThreadPool&>>
     add_task(Function fct, std::string name)
     {
         return add_task(std::move(fct), TimePoint{}, std::move(name));
     }
 
     template <typename Function,
-        std::enable_if_t<is_invocable<Function>::value, bool> = true>
-    TaskHandle<invoke_result_t<Function>>
+        std::enable_if_t<std::is_invocable<Function>::value, bool> = true>
+    TaskHandle<std::invoke_result_t<Function>>
     add_task(Function fct, std::string name)
     {
         return add_task(std::move(fct), TimePoint{}, std::move(name));

--- a/include/gul17/span.h
+++ b/include/gul17/span.h
@@ -128,7 +128,7 @@ template <typename, typename = void>
 struct has_size_and_data : std::false_type {};
 
 template <typename T>
-struct has_size_and_data<T, void_t<decltype(detail::size(std::declval<T>())),
+struct has_size_and_data<T, std::void_t<decltype(detail::size(std::declval<T>())),
                                    decltype(detail::data(std::declval<T>()))>>
     : std::true_type {};
 
@@ -147,7 +147,7 @@ struct is_container_element_type_compatible : std::false_type {};
 
 template <typename T, typename E>
 struct is_container_element_type_compatible<
-    T, E, void_t<decltype(detail::data(std::declval<T>()))>>
+    T, E, std::void_t<decltype(detail::data(std::declval<T>()))>>
     : std::is_convertible<
           remove_pointer_t<decltype(detail::data(std::declval<T>()))> (*)[],
           E (*)[]> {};

--- a/include/gul17/traits.h
+++ b/include/gul17/traits.h
@@ -88,18 +88,6 @@ using remove_cvref = typename std::remove_cv<std::remove_reference_t<T>>;
  */
 template <typename T>
 using remove_cvref_t = typename remove_cvref<T>::type;
-using std::void_t;
-
-
-//
-// invoke & friends
-//
-
-using std::invoke;
-using std::invoke_result;
-using std::invoke_result_t;
-using std::is_invocable;
-using std::is_invocable_r;
 
 /// @}
 

--- a/include/gul17/traits.h
+++ b/include/gul17/traits.h
@@ -1,16 +1,25 @@
 /**
  * \file    traits.h
  * \brief   Some metaprogramming traits for the General Utility Library.
- * \authors \ref contributors, Michael Park
+ * \authors \ref contributors
  * \date    Created on 20 August 2021
  *
- * Copyright 2015-2017 Michael Park (implementations of invoke, invoke_result,
- * invoke_result_t, is_invocable, is_invocable_r), copyright 2021-2024 Deutsches
- * Elektronen-Synchrotron (DESY), Hamburg (other implementations and modifications)
+ * \copyright Copyright 2021-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
- * Distributed under the Boost Software License, Version 1.0.
- * (See \ref license_boost_1_0 or http://boost.org/LICENSE_1_0.txt)
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
+
 
 #ifndef GUL17_TRAITS_H_
 #define GUL17_TRAITS_H_
@@ -85,206 +94,12 @@ using std::void_t;
 //
 // invoke & friends
 //
-#if __cplusplus >= 201703L
 
 using std::invoke;
 using std::invoke_result;
 using std::invoke_result_t;
 using std::is_invocable;
 using std::is_invocable_r;
-
-#else
-
-namespace detail_invoke {
-
-#define GUL17_INVOKE_RETURN(...) \
-  noexcept(noexcept(__VA_ARGS__)) -> decltype(__VA_ARGS__) { return __VA_ARGS__; }
-
-template <typename T>
-struct is_reference_wrapper : std::false_type {};
-
-template <typename T>
-struct is_reference_wrapper<std::reference_wrapper<T>>
-    : std::true_type {};
-
-template <bool, int>
-struct Invoke;
-
-template <>
-struct Invoke<true /* pmf */, 0 /* is_base_of */> {
-    template <typename R, typename T, typename Arg, typename... Args>
-    inline static constexpr auto invoke(R T::*pmf, Arg &&arg, Args &&... args)
-    GUL17_INVOKE_RETURN((std::forward<Arg>(arg).*pmf)(std::forward<Args>(args)...))
-};
-
-template <>
-struct Invoke<true /* pmf */, 1 /* is_reference_wrapper */> {
-    template <typename R, typename T, typename Arg, typename... Args>
-    inline static constexpr auto invoke(R T::*pmf, Arg &&arg, Args &&... args)
-    GUL17_INVOKE_RETURN((std::forward<Arg>(arg).get().*pmf)(std::forward<Args>(args)...))
-};
-
-template <>
-struct Invoke<true /* pmf */, 2 /* otherwise */> {
-    template <typename R, typename T, typename Arg, typename... Args>
-    inline static constexpr auto invoke(R T::*pmf, Arg &&arg, Args &&... args)
-    GUL17_INVOKE_RETURN(((*std::forward<Arg>(arg)).*pmf)(std::forward<Args>(args)...))
-};
-
-template <>
-struct Invoke<false /* pmo */, 0 /* is_base_of */> {
-    template <typename R, typename T, typename Arg>
-    inline static constexpr auto invoke(R T::*pmo, Arg &&arg)
-    GUL17_INVOKE_RETURN(std::forward<Arg>(arg).*pmo)
-};
-
-template <>
-struct Invoke<false /* pmo */, 1 /* is_reference_wrapper */> {
-    template <typename R, typename T, typename Arg>
-    inline static constexpr auto invoke(R T::*pmo, Arg &&arg)
-    GUL17_INVOKE_RETURN(std::forward<Arg>(arg).get().*pmo)
-};
-
-template <>
-struct Invoke<false /* pmo */, 2 /* otherwise */> {
-    template <typename R, typename T, typename Arg>
-    inline static constexpr auto invoke(R T::*pmo, Arg &&arg)
-        GUL17_INVOKE_RETURN((*std::forward<Arg>(arg)).*pmo)
-};
-
-template <typename R, typename T, typename Arg, typename... Args>
-inline constexpr auto invoke(R T::*f, Arg&& arg, Args&&... args)
-    GUL17_INVOKE_RETURN(
-        Invoke<std::is_function<R>::value,
-                (std::is_base_of<T, std::decay_t<Arg>>::value
-                    ? 0
-                    : is_reference_wrapper<std::decay_t<Arg>>::value
-                        ? 1
-                        : 2)>::invoke(f, std::forward<Arg>(arg),
-                                      std::forward<Args>(args)...))
-
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4100)
-#endif
-template <typename F, typename... Args>
-inline constexpr auto invoke(F &&f, Args &&... args)
-    GUL17_INVOKE_RETURN(std::forward<F>(f)(std::forward<Args>(args)...))
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif
-
-#undef GUL17_INVOKE_RETURN
-
-} // namespace detail_invoke
-
-/**
- * Invoke a callable object f with the given arguments.
- *
- * This is a backport of C++17's
- * [std::invoke](https://en.cppreference.com/w/cpp/utility/functional/invoke).
- *
- * \since GUL version 2.11
- */
-template <typename F, typename... Args>
-inline constexpr auto
-invoke(F&& f, Args&&... args) noexcept(
-    noexcept(detail_invoke::invoke(std::forward<F>(f), std::forward<Args>(args)...)))
-    -> decltype(detail_invoke::invoke(std::forward<F>(f), std::forward<Args>(args)...))
-{
-    return detail_invoke::invoke(std::forward<F>(f), std::forward<Args>(args)...);
-}
-
-
-namespace detail_invoke_result {
-
-template <typename T>
-struct identity { using type = T; };
-
-template <typename Void, typename, typename...>
-struct invoke_result {};
-
-template <typename F, typename... Args>
-struct invoke_result<void_t<decltype(invoke(
-                            std::declval<F>(), std::declval<Args>()...))>,
-                        F,
-                        Args...>
-    : identity<decltype(
-            invoke(std::declval<F>(), std::declval<Args>()...))> {};
-
-} // namespace detail_invoke_result
-
-/**
- * A metafunction that computes the result of invoking a callable object of type F with
- * the given arguments. The result is available in the member typedef \c type.
- *
- * This is a backport of C++17's
- * [std::invoke_result](https://en.cppreference.com/w/cpp/types/result_of).
- *
- * \since GUL version 2.11
- */
-template <typename F, typename... Args>
-using invoke_result = detail_invoke_result::invoke_result<void, F, Args...>;
-
-/**
- * A shortcut for invoke_result<...>::type.
- *
- * This is a backport of C++17's
- * [std::invoke_result_t](https://en.cppreference.com/w/cpp/types/result_of).
- *
- * \since GUL version 2.11
- */
-template <typename F, typename... Args>
-using invoke_result_t = typename invoke_result<F, Args...>::type;
-
-
-namespace detail_invocable {
-
-template <typename Void, typename, typename...>
-struct is_invocable : std::false_type {};
-
-template <typename F, typename... Args>
-struct is_invocable<void_t<invoke_result_t<F, Args...>>, F, Args...>
-    : std::true_type {};
-
-template <typename Void, typename, typename, typename...>
-struct is_invocable_r : std::false_type {};
-
-template <typename R, typename F, typename... Args>
-struct is_invocable_r<void_t<invoke_result_t<F, Args...>>,
-                        R,
-                        F,
-                        Args...>
-    : std::is_convertible<invoke_result_t<F, Args...>, R> {};
-
-} // namespace detail_invocable
-
-/**
- * A type trait that checks whether a callable object of type F can be invoked with the
- * given arguments. The boolean result is available in the member \c value.
- *
- * This is a backport of C++17's
- * [std::is_invocable](https://en.cppreference.com/w/cpp/types/is_invocable).
- *
- * \since GUL version 2.11
- */
-template <typename F, typename... Args>
-using is_invocable = detail_invocable::is_invocable<void, F, Args...>;
-
-/**
- * A type trait that checks whether a callable object of type F can be invoked with the
- * given arguments and returns a result convertible to R. The boolean result is available
- * in the member \c value.
- *
- * This is a backport of C++17's
- * [std::is_invocable_r](https://en.cppreference.com/w/cpp/types/is_invocable).
- *
- * \since GUL version 2.11
- */
-template <typename R, typename F, typename... Args>
-using is_invocable_r = detail_invocable::is_invocable_r<void, R, F, Args...>;
-
-#endif // __cplusplus < 201703L
 
 /// @}
 


### PR DESCRIPTION
This PR removes the following symbols from namespace `gul17`:
```
    void_t
    invoke
    invoke_result
    invoke_result_t
    is_invocable
    is_invocable_r
```
All of them are available from the C++17 standard library.
We also remove the associated copyright notice for Michael Park's code which is no longer used.