### PR TITLE
Remove refs to optional, string_view, variant implementations

### DIFF
--- a/data/doxygen.h
+++ b/data/doxygen.h
@@ -79,7 +79,7 @@ namespace gul17 {
  * All functions and classes are enclosed in the namespace \ref gul17.
  *
  * GUL17 requires at least C++17. It works fine with newer versions of the standard, but
- * uses its own backport types (e.g. gul17::string_view) in function interfaces.
+ * might use its own backport types (e.g. gul17::expected) in function interfaces.
  *
  * \section installation Installation
  *
@@ -361,20 +361,10 @@ namespace gul17 {
  *     public domain worldwide. This software is distributed without any warranty.
  *     \ref license_cc0_public_domain and \ref expected.h for details).</dd>
  *
- * <dt>\ref optional.h</dt>
- * <dd>Copyright 2011-2012 Andrzej Krzemienski.
- *     Distributed under the Boost Software License, Version 1.0 (see
- *     \ref license_boost_1_0 and \ref optional.h for details).</dd>
- *
  * <dt>\ref span.h</dt>
  * <dd>Copyright 2018 Tristan Brindle.
  *     Distributed under the Boost Software License, Version 1.0 (see
  *     \ref license_boost_1_0 and \ref span.h for details).</dd>
- *
- * <dt>\ref string_view.h</dt>
- * <dd>Copyright 2012-2015 Marshall Clow, copyright 2015 Beman Dawes.
- *     Distributed under the Boost Software License, Version 1.0 (see
- *     \ref license_boost_1_0 and \ref string_view.h for details).</dd>
  *
  * <dt>\ref traits.h</dt>
  * <dd>Copyright 2015-2017 Michael Park (implementations of invoke, invoke_result,
@@ -382,13 +372,6 @@ namespace gul17 {
  *     Elektronen-Synchrotron (DESY), Hamburg (other implementations and modifications).
  *     Distributed under the Boost Software License, Version 1.0 (see
  *     \ref license_boost_1_0 and \ref traits.h for details).</dd>
- *
- * <dt>\ref variant.h</dt>
- * <dd>Copyright 2015-2017 Michael Park, copyright 2023-2024 Deutsches
- *     Elektronen-Synchrotron (DESY), Hamburg.
- *     Distributed under the Boost Software License, Version 1.0 (see
- *     \ref license_boost_1_0 and \ref variant.h for details).</dd>
- * </dl>
  */
 
 /**
@@ -480,13 +463,6 @@ namespace gul17 {
  * <h4>C Strings</h4>
  *
  * safe_string(): Safely create a std::string from a char pointer and a length.
- *
- * <h3>Classes</h3>
- *
- * \ref gul17::string_view "string_view":
- *     A view to a contiguous sequence of chars. The GUL version is a backport of
- *     [std::string_view](https://en.cppreference.com/w/cpp/string/basic_string_view)
- *     from libc++ for C++17.
  */
 
 /**
@@ -712,12 +688,6 @@ namespace gul17 {
  *     [std::in_place](https://en.cppreference.com/w/cpp/utility/in_place) for
  *     documentation on the corresponding C++17 entities.
  *
- * \ref gul17::optional "optional":
- *     A class template that can either contain a value of a certain type or not.
- *     It should behave like
- *     [std::optional](https://en.cppreference.com/w/cpp/utility/optional)
- *     from C++17 for almost all use cases.
- *
  * \ref gul17::remove_cvref "remove_cvref":
  *     A metafunction to remove const, volatile, and reference qualifiers from a type.
  *     This is a backport of
@@ -728,23 +698,6 @@ namespace gul17 {
  *     A view to a contiguous sequence of objects. It should behave like
  *     [std::span](https://en.cppreference.com/w/cpp/container/span) from C++20 for almost
  *     all use cases.
- *
- * \ref gul17::string_view "string_view":
- *     A view to a contiguous sequence of chars. It should behave like
- *     [std::string_view](https://en.cppreference.com/w/cpp/string/basic_string_view)
- *     from C++17 for almost all use cases.
- *
- * \ref gul17::variant "variant":
- *     Sometimes called a "type-safe union", a variant can hold a value of one of a
- *     specified set of types. Unlike a union, it can be queried for the type it is
- *     currently holding and ensures that only the stored type is accessed. The
- *     implementation should behave like
- *     [std::variant](https://en.cppreference.com/w/cpp/utility/variant) from C++17.
- *
- * \ref gul17::void_t "void_t":
- *     A template typedef that maps an arbitrary list of types to void. This is primarily
- *     useful to detect ill-formed types for SFINAE. This is a backport of
- *     [std::void_t](https://en.cppreference.com/w/cpp/types/void_t) from C++17.
  */
 
 /**
@@ -835,19 +788,6 @@ namespace gul17 {
  *     error value. It should behave like
  *     [std::expected](https://en.cppreference.com/w/cpp/utility/expected)
  *     from C++23 for almost all use cases.
- *
- * \ref gul17::optional "optional":
- *     A class template that can either contain a value of a certain type or not. It
- *     should behave like
- *     [std::optional](https://en.cppreference.com/w/cpp/utility/optional) from C++17 for
- *     almost all use cases.
- *
- * \ref gul17::variant "variant":
- *     Sometimes called a "type-safe union", a variant can hold a value of one of a
- *     specified set of types. Unlike a union, it can be queried for the type it is
- *     currently holding and ensures that only the stored type is accessed. The
- *     implementation should behave like
- *     [std::variant](https://en.cppreference.com/w/cpp/utility/variant) from C++17.
  */
 
 /**

--- a/debian/copyright.in
+++ b/debian/copyright.in
@@ -24,30 +24,14 @@ Copyright: 2017 Sy Brand
            2023-2024 libgul contributors (L. Fröhlich)
 License: CC0
 
-Files: include/gul17/optional.h
-Copyright: 2011-2012 Andrzej Krzemienski
-           2019 libgul contributors (L. Fröhlich)
-License: BSL-1.0
-
 Files: include/gul17/span.h
 Copyright: 2018 Tristan Brindle
            2019 libgul contributors (L. Fröhlich)
 License: BSL-1.0
 
-Files: include/gul17/string_view.h
-Copyright: 2012-2015 Marshall Clow
-           2015 Beman Dawes
-           2018 libgul contributors (L. Fröhlich)
-License: BSL-1.0
-
 Files: include/gul17/traits.h
 Copyright: 2015-2017 Michael Park
            2021-2024 libgul contributors (L. Fröhlich, U.F. Jastrow)
-License: BSL-1.0
-
-Files: include/gul17/variant.h
-Copyright: 2015-2017 Michael Park
-           2023-2024 libgul contributors (L. Fröhlich)
 License: BSL-1.0
 
 License: LGPL-2.1+

--- a/include/gul17/SlidingBuffer.h
+++ b/include/gul17/SlidingBuffer.h
@@ -106,7 +106,7 @@ enum class ShrinkBehavior { keep_front_elements, keep_back_elements };
  * impulse response filter.
  *
  * This container uses an accompanying iterator class called SlidingBufferIterator.
- * See SlidingBufferExposed for a std::variant with a different (more performant) iterator
+ * See SlidingBufferExposed for a variant with a different (more performant) iterator
  * interface.
  *
  * Iterator invalidation is specified at SlidingBufferIterator.
@@ -1027,7 +1027,7 @@ protected:
 };
 
 /**
- * A std::variant of SlidingBuffer that exposes the underlying container through its iterator
+ * A variant of SlidingBuffer that exposes the underlying container through its iterator
  * interface.
  * The direct iterator access to the underlying buffer offers a performance benefit in
  * some cases. However, it comes at the cost of limited flexibility. SlidingBufferExposed

--- a/include/gul17/join_split.h
+++ b/include/gul17/join_split.h
@@ -148,8 +148,9 @@ split(std::string_view text, std::string_view delimiter,
  * Separate a string at all occurrences of a delimiter described by a regular expression,
  * returning the strings between the delimiters in a container.
  *
- * This function is a std::variant of split(std::string_view, std::string_view, ContainerInsertFct)
- * that accepts a std::regex object to describe the delimiter:
+ * This function is a variant of
+ * split(std::string_view, std::string_view, ContainerInsertFct) that accepts a std::regex
+ * object to describe the delimiter:
  * \code
  * // Return type is std::vector<std::string>
  * auto parts = split("one\ntwo\nthree"s, std::regex{"[^[:print:]]"});

--- a/tests/test_SlidingBuffer.cc
+++ b/tests/test_SlidingBuffer.cc
@@ -61,7 +61,7 @@ auto generic_debugdump(std::ostream& s, typename BufferT::size_type len,
     return s << '\n';
 }
 
-// A SlidingBuffer std::variant that allows to dump the underlying container
+// A SlidingBuffer variant that allows to dump the underlying container
 // and the state of the buffer all in one to a stream.
 // We use this to inspect the operations, if they handled internally as expected.
 template<typename ElementT, std::size_t fixed_capacity = 0u,

--- a/tests/test_join_split.cc
+++ b/tests/test_join_split.cc
@@ -4,7 +4,7 @@
  * \date   Created on August 31, 2018
  * \brief  Test suite for join(), split(), and split_sv().
  *
- * \copyright Copyright 2018-2021 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2018-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -25,9 +25,11 @@
 #include <queue>
 #include <regex>
 #include <set>
+#include <string_view>
 #include <string>
 #include <type_traits>
 #include <vector>
+
 #include "gul17/catch.h"
 #include "gul17/join_split.h"
 #include "gul17/SmallVector.h"
@@ -36,7 +38,6 @@ using namespace std::literals::string_literals;
 using gul17::SmallVector;
 using gul17::split;
 using gul17::split_sv;
-using std::string_view;
 using gul17::join;
 
 TEST_CASE("split(std::string_view, std::string_view) with default return type", "[join_split]")


### PR DESCRIPTION
We have removed our custom implementations of optional, string_view, and variant. This commit also removes the associated copyright notices and documentation entries. We also correct some search&replace errors.