### PR TITLE
Rename the Debian package from libgul17 to gul17

### DIFF
--- a/debian/meson.build
+++ b/debian/meson.build
@@ -19,13 +19,13 @@ endif
 deb_install = true
 
 # These are the standard package names
-deb_name_default = 'lib' + meson.project_name()
-deb_dev_name_default = 'lib' + meson.project_name() + '-dev'
+deb_name_default = meson.project_name()
+deb_dev_name_default = meson.project_name() + '-dev'
 
 # Generate package name the user wants to have
 # Thereby @0@ is substituted with the official package name
-deb_name = get_option('deb-name').format('lib' + meson.project_name())
-deb_dev_name = get_option('deb-dev-name').format('lib' + meson.project_name())
+deb_name = get_option('deb-name').format(meson.project_name())
+deb_dev_name = get_option('deb-dev-name').format(meson.project_name())
 
 # Autogenerate debian/changelog
 if not changelogger.found()


### PR DESCRIPTION
I assume this is controversial, but I have to try before we roll out the first packages... :)

# [why]
There is no rule that says that Debian package names have to start with "lib" only because they contain a library. That convention only exists for the .so files themselves because of the way the linker looks for files. "GUL" stands for "General Utility Library", so the "library" part is already contained inside the name, and the "lib" prefix is redundant.