### PR TITLE
Fix unexpected type of string_view iterators on MSVC

### DIFF
--- a/include/gul17/join_split.h
+++ b/include/gul17/join_split.h
@@ -4,7 +4,7 @@
  * \authors \ref contributors
  * \date    Created on 31 August 2018
  *
- * \copyright Copyright 2018-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2018-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -25,13 +25,13 @@
 
 #include <iterator>
 #include <regex>
+#include <string_view>
 #include <string>
 #include <type_traits>
 #include <vector>
 
 #include "gul17/internal.h"
 #include "gul17/string_util.h"
-#include <string_view>
 
 namespace gul17 {
 
@@ -177,7 +177,7 @@ split(std::string_view text, const std::regex& delimiter,
     auto const end = std::cregex_iterator{ };
     auto result = StringContainer{ };
 
-    auto parts = std::cregex_iterator(text.begin(), text.end(), delimiter);
+    auto parts = std::cregex_iterator(text.data(), text.data() + text.size(), delimiter);
     if (parts == end)
     {
         insert_fct(result, text);


### PR DESCRIPTION
# [why]
MSVC complains about the type of our string_view begin() and end() iterators when constructing a cregex_iterator from them. In fact, our own string_view implementation simply returned char* for begin() and end(), but MSVC's standard library returns std::_String_view_iterator<_Traits>.

# [how]
Use data() and data() + size() instead of begin() and end().