### PR TITLE
Clean up includes of string_view, optional, variant

### DIFF
--- a/include/gul17/case_ascii.h
+++ b/include/gul17/case_ascii.h
@@ -5,7 +5,7 @@
  * \authors \ref contributors
  * \date    Created on 28 May 2019
  *
- * \copyright Copyright 2019-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2019-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -24,10 +24,10 @@
 #ifndef GUL17_CASE_ASCII_H_
 #define GUL17_CASE_ASCII_H_
 
+#include <string_view>
 #include <string>
 
 #include "gul17/internal.h"
-#include <string_view>
 
 namespace gul17 {
 

--- a/include/gul17/cat.h
+++ b/include/gul17/cat.h
@@ -5,7 +5,7 @@
  * \brief  Declaration of the overload set for cat() and of the associated class
  *         ConvertingStringView.
  *
- * \copyright Copyright 2018-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2018-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -24,11 +24,11 @@
 #ifndef GUL17_CAT_H_
 #define GUL17_CAT_H_
 
+#include <string_view>
 #include <string>
 #include <type_traits>
 
 #include "gul17/internal.h"
-#include <string_view>
 
 namespace gul17 {
 

--- a/include/gul17/date.h
+++ b/include/gul17/date.h
@@ -12,7 +12,7 @@
  * Copyright (c) 2017 Paul Thompson
  * Copyright (c) 2018, 2019 Tomasz Kamiński
  * Copyright (c) 2019 Jiangang Zhuang
- * Copyright (c) 2022 Deutsches Elektronen-Synchrotron DESY
+ * Copyright (c) 2022-2024 Deutsches Elektronen-Synchrotron DESY
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -40,8 +40,8 @@
 #ifndef GUL17_DATE_H_
 #define GUL17_DATE_H_
 
-#include <cassert>
 #include <algorithm>
+#include <cassert>
 #include <cctype>
 #include <chrono>
 #include <climits>
@@ -60,11 +60,10 @@
 #include <ratio>
 #include <sstream>
 #include <stdexcept>
-#include <string>
-#include <utility>
-#include <type_traits>
-
 #include <string_view>
+#include <string>
+#include <type_traits>
+#include <utility>
 
 /// \cond HIDE_SYMBOLS
 

--- a/include/gul17/escape.h
+++ b/include/gul17/escape.h
@@ -4,7 +4,7 @@
  * \authors \ref contributors
  * \date    Created on 31 August 2018
  *
- * \copyright Copyright 2018-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2018-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -23,10 +23,10 @@
 #ifndef GUL17_ESCAPE_H_
 #define GUL17_ESCAPE_H_
 
+#include <string_view>
 #include <string>
 
 #include "gul17/internal.h"
-#include <string_view>
 
 namespace gul17 {
 

--- a/include/gul17/expected.h
+++ b/include/gul17/expected.h
@@ -1,4 +1,3 @@
-#include <variant>
 /**
  * \file   expected.h
  * \author Sy Brand, \ref contributors
@@ -31,9 +30,9 @@
 #include <functional>
 #include <type_traits>
 #include <utility>
+#include <variant>
 
 #include "gul17/traits.h"
-#include <utility>
 
 namespace gul17 {
 

--- a/include/gul17/gul.h
+++ b/include/gul17/gul.h
@@ -50,14 +50,12 @@
 #include "gul17/hexdump.h"
 #include "gul17/join_split.h"
 #include "gul17/num_util.h"
-#include <optional>
 #include "gul17/replace.h"
 #include "gul17/SlidingBuffer.h"
 #include "gul17/SmallVector.h"
 #include "gul17/span.h"
 #include "gul17/statistics.h"
 #include "gul17/string_util.h"
-#include <string_view>
 #include "gul17/substring_checks.h"
 #include "gul17/ThreadPool.h"
 #include "gul17/time_util.h"
@@ -67,7 +65,6 @@
 #include "gul17/Trigger.h"
 #include "gul17/trim.h"
 #include "gul17/type_name.h"
-#include <variant>
 #include "gul17/version.h"
 
 #endif

--- a/include/gul17/hexdump.h
+++ b/include/gul17/hexdump.h
@@ -4,7 +4,7 @@
  * \date   Created on September 25, 2018
  * \brief  Declaration of the hexdump() functions and associated types.
  *
- * \copyright Copyright 2018-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2018-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -25,11 +25,11 @@
 
 #include <iomanip>
 #include <sstream>
+#include <string_view>
 #include <type_traits>
 #include <utility>
 
 #include "gul17/internal.h"
-#include <string_view>
 
 ////// Overview of the prototypes contained in here, but without template specifications:
 //

--- a/include/gul17/replace.h
+++ b/include/gul17/replace.h
@@ -4,7 +4,7 @@
  * \authors \ref contributors
  * \date    Created on 31 August 2018
  *
- * \copyright Copyright 2018-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2018-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -23,10 +23,10 @@
 #ifndef GUL17_REPLACE_H_
 #define GUL17_REPLACE_H_
 
+#include <string_view>
 #include <string>
 
 #include "gul17/internal.h"
-#include <string_view>
 
 namespace gul17 {
 

--- a/include/gul17/string_util.h
+++ b/include/gul17/string_util.h
@@ -4,7 +4,7 @@
  * \authors \ref contributors
  * \date    Created on 31 August 2018
  *
- * \copyright Copyright 2018-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2018-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -25,10 +25,10 @@
 
 #include <array>
 #include <iterator>
+#include <string_view>
 #include <string>
 
 #include "gul17/internal.h"
-#include <string_view>
 #include "gul17/traits.h"
 
 namespace gul17 {

--- a/include/gul17/substring_checks.h
+++ b/include/gul17/substring_checks.h
@@ -4,7 +4,7 @@
  * \authors \ref contributors
  * \date    Created on 26 November 2018
  *
- * \copyright Copyright 2018-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2018-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -23,9 +23,10 @@
 #ifndef GUL17_SUBSTRING_CHECKS_H_
 #define GUL17_SUBSTRING_CHECKS_H_
 
+#include <string_view>
+
 #include "gul17/case_ascii.h"
 #include "gul17/internal.h"
-#include <string_view>
 
 namespace gul17 {
 

--- a/include/gul17/to_number.h
+++ b/include/gul17/to_number.h
@@ -29,11 +29,11 @@
 #include <cstdlib>
 #include <exception>
 #include <limits>
+#include <optional>
+#include <string_view>
 #include <type_traits>
 
 #include "gul17/internal.h"
-#include <optional>
-#include <string_view>
 #include "gul17/substring_checks.h"
 
 namespace gul17 {

--- a/include/gul17/tokenize.h
+++ b/include/gul17/tokenize.h
@@ -4,7 +4,7 @@
  * \date    Created on September 3, 2018
  * \brief   Implementation of tokenize(), tokenize_sv().
  *
- * \copyright Copyright 2018-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2018-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -23,12 +23,12 @@
 #ifndef GUL17_TOKENIZE_H_
 #define GUL17_TOKENIZE_H_
 
+#include <string_view>
 #include <string>
 #include <vector>
 
 #include "gul17/internal.h"
 #include "gul17/string_util.h"
-#include <string_view>
 
 namespace gul17 {
 

--- a/include/gul17/trim.h
+++ b/include/gul17/trim.h
@@ -5,7 +5,7 @@
  * \brief  Declarations of trim(), trim_left(), trim_right(), trim_sv(), trim_left_sv(),
  *         and trim_right_sv().
  *
- * \copyright Copyright 2018-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2018-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -24,9 +24,10 @@
 #ifndef GUL17_TRIM_H_
 #define GUL17_TRIM_H_
 
+#include <string_view>
+
 #include "gul17/internal.h"
 #include "gul17/string_util.h"
-#include <string_view>
 
 namespace gul17 {
 

--- a/include/gul17/type_name.h
+++ b/include/gul17/type_name.h
@@ -4,7 +4,7 @@
  * \date   Created on April 11, 2019
  * \brief  Definition of type_name()
  *
- * \copyright Copyright 2019-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2019-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -26,8 +26,9 @@
 #ifndef GUL17_TYPE_NAME_H_
 #define GUL17_TYPE_NAME_H_
 
-#include "gul17/internal.h"
 #include <string_view>
+
+#include "gul17/internal.h"
 
 namespace gul17 {
 

--- a/tests/test_backports.cc
+++ b/tests/test_backports.cc
@@ -4,7 +4,7 @@
  * \date   Created on August 30, 2018
  * \brief  Test suite for standard library backports in the General Utility Library.
  *
- * \copyright Copyright 2018-2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2018-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -23,16 +23,8 @@
 #include "gul17/catch.h"
 #include "gul17/date.h"
 #include "gul17/span.h"
-#include <string_view>
 
 using namespace std::literals;
-
-TEST_CASE("std::string_view accepts a string as both char * and std::string, and both "
-          "compare equal", "[std::string_view]")
-{
-    REQUIRE( std::string_view{"Test"} == std::string_view{"Test"s} );
-    REQUIRE( std::string_view{""} == std::string_view{""s} );
-}
 
 TEMPLATE_TEST_CASE("span", "[span]", signed char, unsigned char, short, unsigned short,
                    int, unsigned int, long, unsigned long, long long, unsigned long long)

--- a/tests/test_expected.cc
+++ b/tests/test_expected.cc
@@ -4,7 +4,7 @@
  * \date   Created on March 20, 2023
  * \brief  Unit tests for the expected class template.
  *
- * \copyright Copyright 2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2023-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -21,11 +21,11 @@
  */
 
 #include <memory>
+#include <optional>
 #include <string>
 
 #include "gul17/catch.h"
 #include "gul17/expected.h"
-#include <optional>
 
 using namespace std::literals;
 

--- a/tests/test_tokenize.cc
+++ b/tests/test_tokenize.cc
@@ -4,7 +4,7 @@
  * \date   Created on September 3, 2018
  * \brief  Test suite for tokenize() and tokenize_sv().
  *
- * \copyright Copyright 2018-2021 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2018-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -26,13 +26,14 @@
 #include <queue>
 #include <set>
 #include <stack>
+#include <string_view>
 #include <type_traits>
 #include <unordered_set>
+
+#include "gul17/case_ascii.h"
 #include "gul17/catch.h"
 #include "gul17/SmallVector.h"
-#include <string_view>
 #include "gul17/tokenize.h"
-#include "gul17/case_ascii.h"
 
 using namespace std::literals;
 


### PR DESCRIPTION
This commit removes the standard library headers `<string_view>`, `<optional>`, and `<variant>` from gul.h. There is also a lot of related cleanup in the include sections of our header files.

Also, a unit test for the string_view class is removed.