### PR TITLE
Remove support for old pre-C++17 compilers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ by the library are:
   * Core guideline support library (GSL) excerpts
   * Backports from new standard library extensions
 
-To get started, have a look at ~the [documentation website](https://gul17.info/)~
-the [gul14 documentation website](https://gul14.info/)
+To get started, have a look at the
+[documentation website](https://gul-cpp.github.io/gul17/).
 
 Here you find more detailed information on:
 
@@ -38,7 +38,8 @@ vcpkg installed, just run:~
 
 ## Building <a name="Building"></a>
 
-Clone this repository:
+Needless to say, GUL17 needs a C++17 compliant compiler. To get started, clone this
+repository:
 
         git clone https://github.com/gul-cpp/gul17.git
         cd gul17

--- a/include/gul17/expected.h
+++ b/include/gul17/expected.h
@@ -6,7 +6,7 @@
  *
  * \copyright
  * Written in 2017 by Sy Brand (tartanllama@gmail.com, @TartanLlama)
- * Modifications for GUL17 in 2023-2024 by Lars Fröhlich
+ * Modifications for GUL17 in 2023-2025 by Lars Fröhlich
  *
  * This file is based on version 1.1.0 of Sy Brand's expected.h header from
  * https://github.com/TartanLlama/expected
@@ -104,10 +104,6 @@ class unexpected;
 
 #if defined(__EXCEPTIONS) || defined(_CPPUNWIND)
 #define GUL17_EXPECTED_EXCEPTIONS_ENABLED
-#endif
-
-#if (defined(__GNUC__) && __GNUC__ == 5 && __GNUC_MINOR__ <= 4 && !defined(__clang__))
-#define GUL17_EXPECTED_GCC54
 #endif
 
 #if (defined(__GNUC__) && __GNUC__ == 5 && __GNUC_MINOR__ <= 5 && !defined(__clang__))
@@ -1198,7 +1194,7 @@ public:
   typedef E error_type;
   typedef unexpected<E> unexpected_type;
 
-#if !defined(GUL17_EXPECTED_GCC54) && !defined(GUL17_EXPECTED_GCC55)
+#if !defined(GUL17_EXPECTED_GCC55)
 
   template <class F> constexpr auto and_then(F &&f) & {
     return and_then_impl(*this, std::forward<F>(f));
@@ -1240,7 +1236,7 @@ public:
 
 #endif
 
-#if !defined(GUL17_EXPECTED_GCC54) && !defined(GUL17_EXPECTED_GCC55)
+#if !defined(GUL17_EXPECTED_GCC55)
   template <class F> constexpr auto map(F &&f) & {
     return expected_map_impl(*this, std::forward<F>(f));
   }
@@ -1280,7 +1276,7 @@ public:
   }
 #endif
 
-#if !defined(GUL17_EXPECTED_GCC54) && !defined(GUL17_EXPECTED_GCC55)
+#if !defined(GUL17_EXPECTED_GCC55)
   template <class F> constexpr auto transform(F &&f) & {
     return expected_map_impl(*this, std::forward<F>(f));
   }
@@ -1320,7 +1316,7 @@ public:
   }
 #endif
 
-#if !defined(GUL17_EXPECTED_GCC54) && !defined(GUL17_EXPECTED_GCC55)
+#if !defined(GUL17_EXPECTED_GCC55)
   template <class F> constexpr auto map_error(F &&f) & {
     return map_error_impl(*this, std::forward<F>(f));
   }
@@ -1359,7 +1355,7 @@ public:
     return map_error_impl(std::move(*this), std::forward<F>(f));
   }
 #endif
-#if !defined(GUL17_EXPECTED_GCC54) && !defined(GUL17_EXPECTED_GCC55)
+#if !defined(GUL17_EXPECTED_GCC55)
   template <class F> constexpr auto transform_error(F &&f) & {
     return map_error_impl(*this, std::forward<F>(f));
   }
@@ -2009,7 +2005,7 @@ auto expected_map_impl(Exp &&exp, F &&f) {
   return result(unexpect, std::forward<Exp>(exp).error());
 }
 
-#if !defined(GUL17_EXPECTED_GCC54) && !defined(GUL17_EXPECTED_GCC55)
+#if !defined(GUL17_EXPECTED_GCC55)
 template <class Exp, class F,
           detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
           class Ret = decltype(invoke(std::declval<F>(),

--- a/include/gul17/expected.h
+++ b/include/gul17/expected.h
@@ -106,10 +106,6 @@ class unexpected;
 #define GUL17_EXPECTED_EXCEPTIONS_ENABLED
 #endif
 
-#if (defined(__GNUC__) && __GNUC__ == 5 && __GNUC_MINOR__ <= 5 && !defined(__clang__))
-#define GUL17_EXPECTED_GCC55
-#endif
-
 #if (defined(__GNUC__) && __GNUC__ < 8 && !defined(__clang__))
 #ifndef GUL17_GCC_LESS_8_TRIVIALLY_COPY_CONSTRUCTIBLE_MUTEX
 #define GUL17_GCC_LESS_8_TRIVIALLY_COPY_CONSTRUCTIBLE_MUTEX
@@ -1194,8 +1190,6 @@ public:
   typedef E error_type;
   typedef unexpected<E> unexpected_type;
 
-#if !defined(GUL17_EXPECTED_GCC55)
-
   template <class F> constexpr auto and_then(F &&f) & {
     return and_then_impl(*this, std::forward<F>(f));
   }
@@ -1209,34 +1203,6 @@ public:
     return and_then_impl(std::move(*this), std::forward<F>(f));
   }
 
-#else
-
-  template <class F>
-  constexpr auto
-  and_then(F &&f) & -> decltype(and_then_impl(std::declval<expected &>(),
-                                              std::forward<F>(f))) {
-    return and_then_impl(*this, std::forward<F>(f));
-  }
-  template <class F>
-  constexpr auto
-  and_then(F &&f) && -> decltype(and_then_impl(std::declval<expected &&>(),
-                                               std::forward<F>(f))) {
-    return and_then_impl(std::move(*this), std::forward<F>(f));
-  }
-  template <class F>
-  constexpr auto and_then(F &&f) const & -> decltype(and_then_impl(
-      std::declval<expected const &>(), std::forward<F>(f))) {
-    return and_then_impl(*this, std::forward<F>(f));
-  }
-  template <class F>
-  constexpr auto and_then(F &&f) const && -> decltype(and_then_impl(
-      std::declval<expected const &&>(), std::forward<F>(f))) {
-    return and_then_impl(std::move(*this), std::forward<F>(f));
-  }
-
-#endif
-
-#if !defined(GUL17_EXPECTED_GCC55)
   template <class F> constexpr auto map(F &&f) & {
     return expected_map_impl(*this, std::forward<F>(f));
   }
@@ -1249,34 +1215,7 @@ public:
   template <class F> constexpr auto map(F &&f) const && {
     return expected_map_impl(std::move(*this), std::forward<F>(f));
   }
-#else
-  template <class F>
-  constexpr decltype(expected_map_impl(
-      std::declval<expected &>(), std::declval<F &&>()))
-  map(F &&f) & {
-    return expected_map_impl(*this, std::forward<F>(f));
-  }
-  template <class F>
-  constexpr decltype(expected_map_impl(std::declval<expected>(),
-                                                      std::declval<F &&>()))
-  map(F &&f) && {
-    return expected_map_impl(std::move(*this), std::forward<F>(f));
-  }
-  template <class F>
-  constexpr decltype(expected_map_impl(std::declval<const expected &>(),
-                                       std::declval<F &&>()))
-  map(F &&f) const & {
-    return expected_map_impl(*this, std::forward<F>(f));
-  }
-  template <class F>
-  constexpr decltype(expected_map_impl(std::declval<const expected &&>(),
-                                       std::declval<F &&>()))
-  map(F &&f) const && {
-    return expected_map_impl(std::move(*this), std::forward<F>(f));
-  }
-#endif
 
-#if !defined(GUL17_EXPECTED_GCC55)
   template <class F> constexpr auto transform(F &&f) & {
     return expected_map_impl(*this, std::forward<F>(f));
   }
@@ -1289,34 +1228,7 @@ public:
   template <class F> constexpr auto transform(F &&f) const && {
     return expected_map_impl(std::move(*this), std::forward<F>(f));
   }
-#else
-  template <class F>
-  constexpr decltype(expected_map_impl(
-      std::declval<expected &>(), std::declval<F &&>()))
-  transform(F &&f) & {
-    return expected_map_impl(*this, std::forward<F>(f));
-  }
-  template <class F>
-  constexpr decltype(expected_map_impl(std::declval<expected>(),
-                                                      std::declval<F &&>()))
-  transform(F &&f) && {
-    return expected_map_impl(std::move(*this), std::forward<F>(f));
-  }
-  template <class F>
-  constexpr decltype(expected_map_impl(std::declval<const expected &>(),
-                                       std::declval<F &&>()))
-  transform(F &&f) const & {
-    return expected_map_impl(*this, std::forward<F>(f));
-  }
-  template <class F>
-  constexpr decltype(expected_map_impl(std::declval<const expected &&>(),
-                                       std::declval<F &&>()))
-  transform(F &&f) const && {
-    return expected_map_impl(std::move(*this), std::forward<F>(f));
-  }
-#endif
 
-#if !defined(GUL17_EXPECTED_GCC55)
   template <class F> constexpr auto map_error(F &&f) & {
     return map_error_impl(*this, std::forward<F>(f));
   }
@@ -1329,33 +1241,7 @@ public:
   template <class F> constexpr auto map_error(F &&f) const && {
     return map_error_impl(std::move(*this), std::forward<F>(f));
   }
-#else
-  template <class F>
-  constexpr decltype(map_error_impl(std::declval<expected &>(),
-                                                   std::declval<F &&>()))
-  map_error(F &&f) & {
-    return map_error_impl(*this, std::forward<F>(f));
-  }
-  template <class F>
-  constexpr decltype(map_error_impl(std::declval<expected &&>(),
-                                                   std::declval<F &&>()))
-  map_error(F &&f) && {
-    return map_error_impl(std::move(*this), std::forward<F>(f));
-  }
-  template <class F>
-  constexpr decltype(map_error_impl(std::declval<const expected &>(),
-                                    std::declval<F &&>()))
-  map_error(F &&f) const & {
-    return map_error_impl(*this, std::forward<F>(f));
-  }
-  template <class F>
-  constexpr decltype(map_error_impl(std::declval<const expected &&>(),
-                                    std::declval<F &&>()))
-  map_error(F &&f) const && {
-    return map_error_impl(std::move(*this), std::forward<F>(f));
-  }
-#endif
-#if !defined(GUL17_EXPECTED_GCC55)
+
   template <class F> constexpr auto transform_error(F &&f) & {
     return map_error_impl(*this, std::forward<F>(f));
   }
@@ -1368,32 +1254,7 @@ public:
   template <class F> constexpr auto transform_error(F &&f) const && {
     return map_error_impl(std::move(*this), std::forward<F>(f));
   }
-#else
-  template <class F>
-  constexpr decltype(map_error_impl(std::declval<expected &>(),
-                                                   std::declval<F &&>()))
-  transform_error(F &&f) & {
-    return map_error_impl(*this, std::forward<F>(f));
-  }
-  template <class F>
-  constexpr decltype(map_error_impl(std::declval<expected &&>(),
-                                                   std::declval<F &&>()))
-  transform_error(F &&f) && {
-    return map_error_impl(std::move(*this), std::forward<F>(f));
-  }
-  template <class F>
-  constexpr decltype(map_error_impl(std::declval<const expected &>(),
-                                    std::declval<F &&>()))
-  transform_error(F &&f) const & {
-    return map_error_impl(*this, std::forward<F>(f));
-  }
-  template <class F>
-  constexpr decltype(map_error_impl(std::declval<const expected &&>(),
-                                    std::declval<F &&>()))
-  transform_error(F &&f) const && {
-    return map_error_impl(std::move(*this), std::forward<F>(f));
-  }
-#endif
+
   template <class F> expected constexpr or_else(F &&f) & {
     return or_else_impl(*this, std::forward<F>(f));
   }
@@ -2005,7 +1866,6 @@ auto expected_map_impl(Exp &&exp, F &&f) {
   return result(unexpect, std::forward<Exp>(exp).error());
 }
 
-#if !defined(GUL17_EXPECTED_GCC55)
 template <class Exp, class F,
           detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
           class Ret = decltype(invoke(std::declval<F>(),
@@ -2058,66 +1918,6 @@ auto map_error_impl(Exp &&exp, F &&f) {
   invoke(std::forward<F>(f), std::forward<Exp>(exp).error());
   return result(unexpect, std::monostate{});
 }
-#else
-template <class Exp, class F,
-          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
-          class Ret = decltype(invoke(std::declval<F>(),
-                                              std::declval<Exp>().error())),
-          detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
-constexpr auto map_error_impl(Exp &&exp, F &&f)
-    -> expected<exp_t<Exp>, detail::decay_t<Ret>> {
-  using result = expected<exp_t<Exp>, detail::decay_t<Ret>>;
-
-  return exp.has_value()
-             ? result(*std::forward<Exp>(exp))
-             : result(unexpect, invoke(std::forward<F>(f),
-                                               std::forward<Exp>(exp).error()));
-}
-
-template <class Exp, class F,
-          detail::enable_if_t<!std::is_void<exp_t<Exp>>::value> * = nullptr,
-          class Ret = decltype(invoke(std::declval<F>(),
-                                              std::declval<Exp>().error())),
-          detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
-auto map_error_impl(Exp &&exp, F &&f) -> expected<exp_t<Exp>, std::monostate> {
-  using result = expected<exp_t<Exp>, std::monostate>;
-  if (exp.has_value()) {
-    return result(*std::forward<Exp>(exp));
-  }
-
-  invoke(std::forward<F>(f), std::forward<Exp>(exp).error());
-  return result(unexpect, std::monostate{});
-}
-
-template <class Exp, class F,
-          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
-          class Ret = decltype(invoke(std::declval<F>(),
-                                              std::declval<Exp>().error())),
-          detail::enable_if_t<!std::is_void<Ret>::value> * = nullptr>
-constexpr auto map_error_impl(Exp &&exp, F &&f)
-    -> expected<exp_t<Exp>, detail::decay_t<Ret>> {
-  using result = expected<exp_t<Exp>, detail::decay_t<Ret>>;
-
-  return exp.has_value()
-             ? result()
-             : result(unexpect, invoke(std::forward<F>(f), std::forward<Exp>(exp).error()));
-}
-
-template <class Exp, class F,
-          detail::enable_if_t<std::is_void<exp_t<Exp>>::value> * = nullptr,
-          class Ret = decltype(invoke(std::declval<F>(),
-                                              std::declval<Exp>().error())),
-          detail::enable_if_t<std::is_void<Ret>::value> * = nullptr>
-auto map_error_impl(Exp &&exp, F &&f) -> expected<exp_t<Exp>, std::monostate> {
-  using result = expected<exp_t<Exp>, std::monostate>;
-  if (exp.has_value()) {
-    return result();
-  }
-
-  invoke(std::forward<F>(f), std::forward<Exp>(exp).error());
-  return result(unexpect, std::monostate{});
-}
-#endif
 
 template <class Exp, class F,
           class Ret = decltype(invoke(std::declval<F>(),

--- a/include/gul17/span.h
+++ b/include/gul17/span.h
@@ -5,7 +5,7 @@
  *
  * \copyright
  * Copyright Tristan Brindle 2018.
- * Copyright Deutsches Elektronen-Synchrotron (DESY), Hamburg 2019-2023 (modifications for
+ * Copyright Deutsches Elektronen-Synchrotron (DESY), Hamburg 2019-2025 (modifications for
  * GUL, \ref contributors).
  *
  * Distributed under the Boost Software License, Version 1.0. (See \ref license_boost_1_0
@@ -38,13 +38,6 @@ namespace gul17 {
  */
 
 /// \cond HIDE_SYMBOLS
-
-// Feature test macro for defaulted constexpr assignment operator
-#if (!defined(_MSC_VER) || _MSC_VER > 1900)
-#define GUL_SPAN_CONSTEXPR_ASSIGN constexpr
-#else
-#define GUL_SPAN_CONSTEXPR_ASSIGN
-#endif
 
 constexpr std::size_t dynamic_extent = SIZE_MAX;
 
@@ -292,7 +285,7 @@ public:
     ~span() noexcept = default;
 
     /// See [std::span](https://en.cppreference.com/w/cpp/container/span).
-    GUL_SPAN_CONSTEXPR_ASSIGN span&
+    constexpr span&
     operator=(const span& other) noexcept = default;
 
     // [span.sub], span subviews

--- a/include/gul17/utility.h
+++ b/include/gul17/utility.h
@@ -1,1 +1,0 @@
-using std::in_place_t;


### PR DESCRIPTION
These commits remove compatibility kludges for pre-C++17 compilers. These kludges make no sense anymore for GUL17 because we require a standards compliant C++17 compiler in the first place.