### PR TITLE
Allow bugfix updates

### DIFF
--- a/debian/check_control
+++ b/debian/check_control
@@ -21,7 +21,7 @@ cd "$(dirname "$0")/.."
 
 # LIBNO-file can contain "LIBNO = 24.1.1-oracular1" (The part after x.y.z is optional)
 # VERSION contains dots: 24.1.2-oracular1
-VERSION=$(grep LIBNO LIBNO | sed -e "s/LIBNO *= *//g")
+VERSION=$(sed -e "s/LIBNO\s*=\s*//g;s/\s\+$//" LIBNO )
 
 # # LIBNO contains dashes: 24-1-2-oracular1
 # LIBNO=$(echo "${VERSION}" | sed -e "s/\./-/g")
@@ -29,7 +29,7 @@ VERSION=$(grep LIBNO LIBNO | sed -e "s/LIBNO *= *//g")
 # LIBNO contains dashes and no suffix: 24-1-2
 LIBNO=$(echo "${VERSION}" | sed -E "s/([0-9]+\.[0-9]+\.[0-9]+).*/\1/;s/\./-/g")
 
-# LIBNAME contains the pure name without version parts
+# LIBNAME contains the pure (package) name without version parts
 LIBNAME=$(grep "^Source:" debian/control | sed 's/Source: *//;s/-[0-9].*$//')
 
 # Check version number in control file

--- a/debian/check_control
+++ b/debian/check_control
@@ -8,6 +8,7 @@
 #
 # In both cases you probably want to commit the changes this script did.
 
+# Version 03.03.2025 (exclude suffix from package name (GUL only))
 # Version 02.03.2025 (changelog check more robust)
 # Version 19.02.2025 (fix sed command)
 # Version 18.02.2025 (preserve other dependencies)
@@ -22,8 +23,11 @@ cd "$(dirname "$0")/.."
 # VERSION contains dots: 24.1.2-oracular1
 VERSION=$(grep LIBNO LIBNO | sed -e "s/LIBNO *= *//g")
 
-# LIBNO contains dashes: 24-1-2-oracular1
-LIBNO=$(echo "${VERSION}" | sed -e "s/\./-/g")
+# # LIBNO contains dashes: 24-1-2-oracular1
+# LIBNO=$(echo "${VERSION}" | sed -e "s/\./-/g")
+
+# LIBNO contains dashes and no suffix: 24-1-2
+LIBNO=$(echo "${VERSION}" | sed -E "s/([0-9]+\.[0-9]+\.[0-9]+).*/\1/;s/\./-/g")
 
 # LIBNAME contains the pure name without version parts
 LIBNAME=$(grep "^Source:" debian/control | sed 's/Source: *//;s/-[0-9].*$//')

--- a/debian/check_control
+++ b/debian/check_control
@@ -8,6 +8,7 @@
 #
 # In both cases you probably want to commit the changes this script did.
 
+# Version 02.03.2025 (changelog check more robust)
 # Version 19.02.2025 (fix sed command)
 # Version 18.02.2025 (preserve other dependencies)
 # Version 22.01.2025 (make calling pwd in dependent)
@@ -17,20 +18,21 @@ set -e
 
 cd "$(dirname "$0")/.."
 
-# LIBNO-file contains "LIBNO = 24.1.1"
-# VERSION contains dots 24.1.2
-# LIBNO contains dashes 24-1-2
-VERSION=$(grep LIBNO LIBNO | sed -e "s/LIBNO = //g")
+# LIBNO-file can contain "LIBNO = 24.1.1-oracular1" (The part after x.y.z is optional)
+# VERSION contains dots: 24.1.2-oracular1
+VERSION=$(grep LIBNO LIBNO | sed -e "s/LIBNO *= *//g")
+
+# LIBNO contains dashes: 24-1-2-oracular1
 LIBNO=$(echo "${VERSION}" | sed -e "s/\./-/g")
 
-# check version number in control file
+# LIBNAME contains the pure name without version parts
 LIBNAME=$(grep "^Source:" debian/control | sed 's/Source: *//;s/-[0-9].*$//')
-LIKELY=$(grep "Source: ${LIBNAME}-${LIBNO}" debian/control || true)
 
-# if LIBNO and version in debian/control differs update
-# debian/control and debian/changelog
-if [ -z "$LIKELY" ]; then
-    sed -i -e "s/${LIBNAME}-[^ ]*/${LIBNAME}-${LIBNO}/g" debian/control
+# Check version number in control file
+sed -i -e "s/${LIBNAME}-[^ ]*/${LIBNAME}-${LIBNO}/g" debian/control
+
+# If LIBNO and version in debian/changelog differs: update
+if ! head -n 1 debian/changelog | grep "${LIBNAME}-${LIBNO}" | grep "\(${VERSION}\)" ; then
     debchange \
         --controlmaint \
         --newversion="${VERSION}" \


### PR DESCRIPTION
While Doocs usually uses a rigid linking structure where the library version current at build time is always used for that executable, GUL14 allowed for some minuscule updates. If a very tiny bugfix of GUL14 is created where the LIBNO does not change; and a new package is built with `makeDdeb -l 2` (for example), this library will update the previous one and is not hard attached to the executable.

Less abstract:

Linking is by so-name and update of packages is per package-name by version.

With classic Doocs libraries the complete version is also in the name. That means the library package can not be 'bugfixed' but instead a new package with a different name is added. Packages and executables use the library version (down to suffix) that has been present at executable-build time.

For example: `libcam` with version `22.11.0` is installed two times on `doocsdev20`:

```console
$ apt-file search libcam.so.22.11.0
doocs-camlib-22-11-0-focal1: /export/doocs/lib/libcam.so.22.11.0-focal1
doocs-camlib-22-11-0-focal2: /export/doocs/lib/libcam.so.22.11.0-focal2
```

![image](https://github.com/user-attachments/assets/23c7b3f9-c97b-4ded-8d1c-e1dc8c34756c)

The version including suffix is in both the package name `doocs-camlib-22-11-0-focal2` and in the version string `22.11.0-focal2`.

GUL14 on the other hand does follow this Doocs convention (to some extend), but does allow updates within one and the same Doocs release:

![image](https://github.com/user-attachments/assets/66b99a09-1c4a-460f-af5f-ded50f97dc1c)

The version **_suffix_** is only the the version `22.11.0-focal1` but not in the package name `doocs-libgul14-22-11-0` and so would allow to update to version `22.11.0-focal2`, even for executables that were initially built with `22.11.0-focal1`.

This change reinstates that behavior to GUL17, that has been lost when rewriting the packaging.

Fixes: #14