### PR TITLE
CI: Fix generation of documentation

### DIFF
--- a/.github/workflows/doxygen.yml
+++ b/.github/workflows/doxygen.yml
@@ -49,12 +49,13 @@ jobs:
 
       - name: Call Doxygen
         run: |
-          make doc
+          meson setup build
+          ninja -C build data/docs
 
       - name: Publish Docu
         uses: JamesIves/github-pages-deploy-action@v4
         with:
-          folder: "build/x86_64-linux/release/data/doxygenerated/html"
+          folder: "build/data/doxygenerated/html"
           target-folder: "docs"
           clean: true
           commit-message: "[ci] Regenerate Doxygen docs"


### PR DESCRIPTION
[why]
The makefile has been dropped.

[how]
Pull the commands from the (old) Makefile into the CI script.

Fixes: #16