### PR TITLE
Meson: Honor value of default_library option

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -1,9 +1,9 @@
 executable('trim_example', 'trim.cc',
-    dependencies : [ libgul_static_dep ],
+    dependencies : [ libgul_dep ],
     build_by_default : false,
 )
 
 executable('thread_pool_example', 'thread_pool.cc',
-    dependencies : [ libgul_static_dep ],
+    dependencies : [ libgul_dep ],
     build_by_default : false,
 )

--- a/meson.build
+++ b/meson.build
@@ -10,6 +10,7 @@ project('gul17', 'cpp',
         'libdir=lib',
         'includedir=lib/include',
         'warning_level=3',
+        'default_library=both',
     ],
     version : run_command(
         [

--- a/src/meson.build
+++ b/src/meson.build
@@ -54,33 +54,51 @@ endif
 
 deps = dependency('threads')
 
-libgul = shared_library(
-    meson.project_name(), libgul_src + [ version_cc ],
-    soversion : so_version,
-    cpp_args : add_cpp_args + [ '-DGUL_COMPILING_SHARED_LIB' ],
-    dependencies : deps,
-    include_directories : inc,
-    gnu_symbol_visibility : 'hidden',
-    install : true
-)
-libgul_static = static_library(
-    meson.project_name(), libgul_src + [ version_cc ],
-    cpp_args : add_cpp_args + [ '-DGUL_USING_STATIC_LIB_OR_OBJECTS' ],
-    dependencies : deps,
-    include_directories : inc,
-    install : true
-)
-libgul_dep = declare_dependency(
-    dependencies : deps,
-    include_directories : inc,
-    link_with : libgul,
-)
-libgul_static_dep = declare_dependency(
-    dependencies : deps,
-    include_directories : inc,
-    link_with : libgul_static,
-    compile_args : [ '-DGUL_USING_STATIC_LIB_OR_OBJECTS' ],
-)
+## Static and shared libraries
+
+if get_option('default_library') in ['both', 'static']
+    libgul_static = static_library(
+        meson.project_name(), libgul_src + [ version_cc ],
+        cpp_args : add_cpp_args + [ '-DGUL_USING_STATIC_LIB_OR_OBJECTS' ],
+        dependencies : deps,
+        include_directories : inc,
+        install : true
+    )
+
+    libgul_static_dep = declare_dependency(
+        dependencies : deps,
+        include_directories : inc,
+        link_with : libgul_static,
+        compile_args : [ '-DGUL_USING_STATIC_LIB_OR_OBJECTS' ],
+    )
+
+    libgul = libgul_static
+    libgul_dep = libgul_static_dep
+endif
+
+if get_option('default_library') in ['both', 'shared']
+    libgul_shared = shared_library(
+        meson.project_name(), libgul_src + [ version_cc ],
+        soversion : so_version,
+        cpp_args : add_cpp_args + [ '-DGUL_COMPILING_SHARED_LIB' ],
+        dependencies : deps,
+        include_directories : inc,
+        gnu_symbol_visibility : 'hidden',
+        install : true
+    )
+
+    libgul_shared_dep = declare_dependency(
+        dependencies : deps,
+        include_directories : inc,
+        link_with : libgul_shared,
+    )
+
+    libgul = libgul_shared
+    libgul_dep = libgul_shared_dep
+endif
+
+
+## Pkg-config file
 
 pkg = import('pkgconfig')
 pkg.generate(


### PR DESCRIPTION
**[why]**  
So far, we always provided build targets for both the static and the shared library in our build script. This did not allow users to simply select their desired library type via the standard "default_library" option.

**[how]**  
Set a project default of `default_library=both` and provide the shared and static library build targets only if they are part of the user-selected default_library option.

**[note]**  
Related: https://github.com/gul-cpp/gul14/pull/96
Fixes: #11