### PR TITLE
Install to /usr instead of /export/doocs

### DIFF
--- a/.gitlab-ci/build.yml
+++ b/.gitlab-ci/build.yml
@@ -153,9 +153,9 @@ Windows test:
         script:
                 - meson
                   --buildtype=debugoptimized
-                  --prefix=/export/doocs
+                  --prefix=/usr
                   --libdir=lib
-                  --includedir=lib/include
+                  --includedir=include
                   build.release
                 - ninja -C build.release
         artifacts:

--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ Overview of maybe useful standard project options:
 
     Option         Default Value         Description
     ------         -------------         -----------
-    prefix         /export/doocs         Installation prefix
-    libdir         lib/...               Library directory
-    includedir     lib/include           Header file directory
+    prefix         /usr                  Installation prefix
+    libdir         lib                   Library directory
+    includedir     include               Header file directory
     datadir        share                 Data file (Doxygen website) directory
 
 ### Building on Windows with Visual C++ <a name="Building-on-Windows-with-Visual-C"></a>

--- a/debian/dev-doocs-gul17.install
+++ b/debian/dev-doocs-gul17.install
@@ -1,4 +1,4 @@
-export/doocs/lib/*.a
-export/doocs/lib/*.so
-export/doocs/lib/include/*
-export/doocs/lib/pkgconfig/*
+usr/lib/*.a
+usr/lib/*.so
+usr/include/*
+usr/lib/pkgconfig/*

--- a/debian/doocs-gul17.install.in
+++ b/debian/doocs-gul17.install.in
@@ -1,1 +1,1 @@
-export/doocs/lib/*.so.*
+usr/lib/*.so.*

--- a/debian/rules
+++ b/debian/rules
@@ -15,11 +15,11 @@ override_dh_auto_configure:
 	debian/check_control
 	dh_auto_configure -- \
 		--buildtype=debugoptimized \
-		--prefix=/export/doocs \
+		--prefix=/usr \
 		--libdir=lib \
-		--includedir=lib/include \
+		--includedir=include \
 		--wrap-mode=nofallback \
-		--pkg-config-path=/export/doocs/lib/pkgconfig
+		--pkg-config-path=/usr/lib/pkgconfig
 
 override_dh_strip:
 	@echo "Not running dh_strip to retain debug symbols in library"


### PR DESCRIPTION
GUL17 is a general-purpose library. It would be weird to install it into /export/doocs if it were to be used outside of a DOOCS context. Even in the DOOCS world, there is no disadvantage in installing it to /usr. Other libraries like TINE do not follow the /export/doocs scheme either.

In the end, this boils down to a matter of taste. But we do not necessarily have to follow all the weirdness of the DOOCS world, do we?