### PR TITLE
Bring package name more in line with Debian standards

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-doocs-gul17-1-2-3 (1.2.3) unstable; urgency=low
+gul17-1-2-3 (1.2.3) unstable; urgency=low
 
   * Dummy release.
 

--- a/debian/clean
+++ b/debian/clean
@@ -1,2 +1,2 @@
-debian/doocs-gul17-[0-9]*.install
+debian/gul17-[0-9]*.install
 debian/build/

--- a/debian/control
+++ b/debian/control
@@ -1,4 +1,4 @@
-Source: doocs-gul17-1-2-3
+Source: gul17-1-2-3
 Priority: optional
 Maintainer: Fini Jastrow <ulf.fini.jastrow@desy.de>
 Build-Depends: debhelper-compat (=12), meson (>=0.53.2), ninja-build (>=1.5.1), catch2 (>3.4.0)
@@ -6,7 +6,7 @@ Standards-Version: 4.5.0
 Section: libs
 Homepage: https://github.com/gul-cpp/gul17
 
-Package: doocs-gul17-1-2-3
+Package: gul17-1-2-3
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Description: General Utility Library for C++17
@@ -14,10 +14,10 @@ Description: General Utility Library for C++17
  functions and types that form the foundation for other
  libraries and programs.
 
-Package: dev-doocs-gul17
+Package: gul17-dev
 Section: libdevel
 Architecture: any
-Depends: doocs-gul17-1-2-3 (= ${binary:Version}), ${misc:Depends}
+Depends: gul17-1-2-3 (= ${binary:Version}), ${misc:Depends}
 Description: General Utility Library for C++17 development files
  The General Utility Library for C++17 contains often-used utility
  functions and types that form the foundation for other


### PR DESCRIPTION
This commit changes the Debian package names from `doocs-gul17-1-2-3` and `dev-doocs-gul17` to `gul17-1-2-3` and `gul17-dev`. This is a little more in line with Debian standards. Including the version number in the binary package is also nonstandard, but unfortunately necessary for our usage scenario.