### PR TITLE
Add missing <algorithm> include

### DIFF
--- a/tests/test_ThreadPool.cc
+++ b/tests/test_ThreadPool.cc
@@ -22,6 +22,7 @@
 
 // SPDX-License-Identifier: LGPL-2.1-or-later
 
+#include <algorithm>
 #include <array>
 #include <atomic>
 #include <stdexcept>


### PR DESCRIPTION
We use std::sort(), which is contained in `<algorithm>`. Fixes #25.