### PR TITLE
Add safe_string_view()

### DIFF
--- a/include/gul17/string_util.h
+++ b/include/gul17/string_util.h
@@ -254,9 +254,9 @@ std::string repeat(std::string_view str, std::size_t n);
  * auto d = safe_string("AB\0CD", 5); // d == "AB"s, intermediate zero byte ends the string
  * \endcode
  *
- * \param char_ptr  Pointer to a C string, an unterminated string of at least the
- *                  specified length, or null.
- * \param length    Maximum length of the generated string.
+ * \param char_ptr  Pointer to a string that is either null-terminated or has at least
+ *                  \c length accessible bytes, or a null pointer
+ * \param length    Maximum length of the generated string
  *
  * \since GUL version 2.6
  */
@@ -278,8 +278,8 @@ std::string safe_string(const char* char_ptr, std::size_t length);
  * auto d = safe_string_view("AB\0CD", 5); // d == "AB"sv, intermediate zero byte ends the string
  * \endcode
  *
- * \param char_ptr  Pointer to a C string, an unterminated string of at least the
- *                  specified length, or null
+ * \param char_ptr  Pointer to a string that is either null-terminated or has at least
+ *                  \c length accessible bytes, or a null pointer
  * \param length    Maximum length of the generated string_view
  *
  * \since GUL version UNRELEASED

--- a/include/gul17/string_util.h
+++ b/include/gul17/string_util.h
@@ -4,7 +4,7 @@
  * \authors \ref contributors
  * \date    Created on 31 August 2018
  *
- * \copyright Copyright 2018-2024 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2018-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -262,6 +262,30 @@ std::string repeat(std::string_view str, std::size_t n);
  */
 GUL_EXPORT
 std::string safe_string(const char* char_ptr, std::size_t length);
+
+/**
+ * Safely construct a string_view from a char pointer and a length.
+ *
+ * If the pointer is null, an empty string_view is constructed. If there are no zero bytes
+ * in the input range, a string_view of length \c length is constructed. Otherwise, the
+ * input string is treated as a C string and the first zero byte is treated as the end of
+ * the string.
+ *
+ * \code
+ * auto a = safe_string_view(nullptr, 5);  // a == ""sv
+ * auto b = safe_string_view("ABC", 2);    // b == "AB"sv
+ * auto c = safe_string_view("ABC", 4);    // c == "ABC"sv, trailing zero byte ends the string
+ * auto d = safe_string_view("AB\0CD", 5); // d == "AB"sv, intermediate zero byte ends the string
+ * \endcode
+ *
+ * \param char_ptr  Pointer to a C string, an unterminated string of at least the
+ *                  specified length, or null
+ * \param length    Maximum length of the generated string_view
+ *
+ * \since GUL version UNRELEASED
+ */
+GUL_EXPORT
+std::string_view safe_string_view(const char* char_ptr, std::size_t length);
 
 /// @}
 

--- a/src/string_util.cc
+++ b/src/string_util.cc
@@ -4,7 +4,7 @@
  * \authors \ref contributors
  * \date    Created on 31 August 2018
  *
- * \copyright Copyright 2018-2022 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2018-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -49,6 +49,16 @@ std::string safe_string(const char* char_ptr, std::size_t length)
     auto end_ptr = std::find(char_ptr, char_ptr + length, '\0');
 
     return std::string(char_ptr, end_ptr);
+}
+
+std::string_view safe_string_view(const char* char_ptr, std::size_t length)
+{
+    if (char_ptr == nullptr)
+        return {};
+
+    auto end_ptr = std::find(char_ptr, char_ptr + length, '\0');
+
+    return std::string_view(char_ptr, end_ptr - char_ptr);
 }
 
 } // namespace gul17

--- a/tests/test_string_util.cc
+++ b/tests/test_string_util.cc
@@ -32,7 +32,6 @@
 
 using gul17::hex_string;
 using gul17::repeat;
-using gul17::safe_string;
 
 using namespace std::literals;
 
@@ -126,10 +125,26 @@ TEST_CASE("repeat()", "[string_util]")
 
 TEST_CASE("safe_string()", "[string_util]")
 {
+    using gul17::safe_string;
+
     REQUIRE(safe_string(nullptr, 0) == "");
     REQUIRE(safe_string(nullptr, 10) == "");
     REQUIRE(safe_string("hello", 0) == "");
     REQUIRE(safe_string("hello", 10) == "hello");
     REQUIRE(safe_string("hello\0", 6) == "hello");
     REQUIRE(safe_string("hello\0world", 11) == "hello");
+}
+
+TEST_CASE("safe_string_view()", "[string_util]")
+{
+    using gul17::safe_string_view;
+
+    REQUIRE(safe_string_view(nullptr, 10) == std::string_view{});
+    REQUIRE(safe_string_view("", 0) == ""sv);
+    REQUIRE(safe_string_view("", 1) == ""sv);
+    REQUIRE(safe_string_view("ABC", 0) == ""sv);
+    REQUIRE(safe_string_view("ABC", 2) == "AB"sv);
+    REQUIRE(safe_string_view("ABC", 3) == "ABC"sv);
+    REQUIRE(safe_string_view("ABC", 4) == "ABC"sv);
+    REQUIRE(safe_string_view("AB\0CD", 5) == "AB"sv);
 }


### PR DESCRIPTION
This PR adds a `safe_string_view()` function that, just like `safe_string()` creates a std::string from a char pointer and a length, creates a string_view instead. The function is safe against null pointers and strings without null termination.

I also add a CHANGELOG.md; we should discuss if we want that. Maybe it would make the workflow a bit nicer compared to the Doxygen gymnastics we do so far for the release notes.