### PR TITLE
Add single-argument overloads safe_string(const char*) and safe_string_view(const char*)

### DIFF
--- a/data/doxygen.h
+++ b/data/doxygen.h
@@ -148,10 +148,9 @@ namespace gul17 {
  *
  * \subsection V25_X_X UNRELEASED
  *
- * - Add gul17::safe_string(const char*) and gul17::safe_string_view(const char*)
- *   to complement the existing overloads with a length argument. The new functions
- *   construct a string or string_view from a null-terminated C string and are safe
- *   against null pointers.
+ * - Add gul17::null_safe_string(const char*) and
+ *   gul17::null_safe_string_view(const char*). The new functions construct a string or
+ *   string_view from a null-terminated C string and are safe against null pointers.
  *
  * \subsection V25_4_0 Version 25.4.0
  *

--- a/data/doxygen.h
+++ b/data/doxygen.h
@@ -146,6 +146,13 @@ namespace gul17 {
  *
  * \section changelog_gul17 GUL17 Versions
  *
+ * \subsection V25_X_X UNRELEASED
+ *
+ * - Add gul17::safe_string(const char*) and gul17::safe_string_view(const char*)
+ *   to complement the existing overloads with a length argument. The new functions
+ *   construct a string or string_view from a null-terminated C string and are safe
+ *   against null pointers.
+ *
  * \subsection V25_4_0 Version 25.4.0
  *
  * - Add gul17::safe_string_view(). The function constructs a string_view from a char

--- a/include/gul17/string_util.h
+++ b/include/gul17/string_util.h
@@ -264,6 +264,25 @@ GUL_EXPORT
 std::string safe_string(const char* char_ptr, std::size_t length);
 
 /**
+ * Safely construct a std::string from a C string or a null pointer.
+ *
+ * If the pointer is null, an empty string is constructed. Otherwise, the function assumes
+ * to find a zero-terminated C string and constructs a std::string from it.
+ *
+ * \code
+ * auto a = safe_string(nullptr);  // a == ""s
+ * auto b = safe_string("ABC");    // b == "ABC"s
+ * auto c = safe_string("AB\0CD"); // c == "AB"s
+ * \endcode
+ *
+ * \param char_ptr  Pointer to a null-terminated string or a null pointer
+ *
+ * \since GUL version UNRELEASED
+ */
+GUL_EXPORT
+std::string safe_string(const char* char_ptr);
+
+/**
  * Safely construct a string_view from a char pointer and a length.
  *
  * If the pointer is null, an empty string_view is constructed. If there are no zero bytes

--- a/include/gul17/string_util.h
+++ b/include/gul17/string_util.h
@@ -306,6 +306,25 @@ std::string safe_string(const char* char_ptr);
 GUL_EXPORT
 std::string_view safe_string_view(const char* char_ptr, std::size_t length);
 
+/**
+ * Safely construct a string_view from a char pointer.
+ *
+ * If the pointer is null, an empty string_view is constructed.  Otherwise, the function
+ * assumes to find a zero-terminated C string and constructs a std::string_view from it.
+ *
+ * \code
+ * auto a = safe_string_view(nullptr);  // a == ""sv
+ * auto b = safe_string_view("ABC");    // b == "ABC"sv
+ * auto c = safe_string_view("AB\0CD"); // c == "AB"sv
+ * \endcode
+ *
+ * \param char_ptr  Pointer to a null-terminated string or a null pointer
+ *
+ * \since GUL version UNRELEASED
+ */
+GUL_EXPORT
+std::string_view safe_string_view(const char* char_ptr);
+
 /// @}
 
 } // namespace gul17

--- a/include/gul17/string_util.h
+++ b/include/gul17/string_util.h
@@ -224,6 +224,48 @@ hex_string(const Container& container, std::string_view separator = "")
 }
 
 /**
+ * Safely construct a std::string from a C string or a null pointer.
+ *
+ * If the pointer is null, an empty string is constructed. Otherwise, the function assumes
+ * to find a zero-terminated C string and constructs a std::string from it.
+ *
+ * \code
+ * auto a = safe_string(nullptr);  // a == ""s
+ * auto b = safe_string("ABC");    // b == "ABC"s
+ * auto c = safe_string("AB\0CD"); // c == "AB"s
+ * \endcode
+ *
+ * \param char_ptr  Pointer to a null-terminated string or a null pointer
+ *
+ * \see safe_string(), null_safe_string_view()
+ *
+ * \since GUL version UNRELEASED
+ */
+GUL_EXPORT
+std::string null_safe_string(const char* char_ptr);
+
+/**
+ * Safely construct a string_view from a char pointer.
+ *
+ * If the pointer is null, an empty string_view is constructed.  Otherwise, the function
+ * assumes to find a zero-terminated C string and constructs a std::string_view from it.
+ *
+ * \code
+ * auto a = safe_string_view(nullptr);  // a == ""sv
+ * auto b = safe_string_view("ABC");    // b == "ABC"sv
+ * auto c = safe_string_view("AB\0CD"); // c == "AB"sv
+ * \endcode
+ *
+ * \param char_ptr  Pointer to a null-terminated string or a null pointer
+ *
+ * \see safe_string_view(), null_safe_string()
+ *
+ * \since GUL version UNRELEASED
+ */
+GUL_EXPORT
+std::string_view null_safe_string_view(const char* char_ptr);
+
+/**
  * Repeat a string N times.
  * \code
  * std::string str = repeat("du", 3); // str == "dududu"
@@ -258,29 +300,12 @@ std::string repeat(std::string_view str, std::size_t n);
  *                  \c length accessible bytes, or a null pointer
  * \param length    Maximum length of the generated string
  *
+ * \see null_safe_string(), safe_string_view()
+ *
  * \since GUL version 2.6
  */
 GUL_EXPORT
 std::string safe_string(const char* char_ptr, std::size_t length);
-
-/**
- * Safely construct a std::string from a C string or a null pointer.
- *
- * If the pointer is null, an empty string is constructed. Otherwise, the function assumes
- * to find a zero-terminated C string and constructs a std::string from it.
- *
- * \code
- * auto a = safe_string(nullptr);  // a == ""s
- * auto b = safe_string("ABC");    // b == "ABC"s
- * auto c = safe_string("AB\0CD"); // c == "AB"s
- * \endcode
- *
- * \param char_ptr  Pointer to a null-terminated string or a null pointer
- *
- * \since GUL version UNRELEASED
- */
-GUL_EXPORT
-std::string safe_string(const char* char_ptr);
 
 /**
  * Safely construct a string_view from a char pointer and a length.
@@ -301,29 +326,12 @@ std::string safe_string(const char* char_ptr);
  *                  \c length accessible bytes, or a null pointer
  * \param length    Maximum length of the generated string_view
  *
+ * \see null_safe_string_view(), safe_string()
+ *
  * \since GUL version 25.4.0
  */
 GUL_EXPORT
 std::string_view safe_string_view(const char* char_ptr, std::size_t length);
-
-/**
- * Safely construct a string_view from a char pointer.
- *
- * If the pointer is null, an empty string_view is constructed.  Otherwise, the function
- * assumes to find a zero-terminated C string and constructs a std::string_view from it.
- *
- * \code
- * auto a = safe_string_view(nullptr);  // a == ""sv
- * auto b = safe_string_view("ABC");    // b == "ABC"sv
- * auto c = safe_string_view("AB\0CD"); // c == "AB"sv
- * \endcode
- *
- * \param char_ptr  Pointer to a null-terminated string or a null pointer
- *
- * \since GUL version UNRELEASED
- */
-GUL_EXPORT
-std::string_view safe_string_view(const char* char_ptr);
 
 /// @}
 

--- a/src/string_util.cc
+++ b/src/string_util.cc
@@ -51,6 +51,16 @@ std::string safe_string(const char* char_ptr, std::size_t length)
     return std::string(char_ptr, end_ptr);
 }
 
+std::string safe_string(const char* char_ptr)
+{
+    std::string result;
+
+    if (char_ptr)
+        result = char_ptr;
+
+    return result;
+}
+
 std::string_view safe_string_view(const char* char_ptr, std::size_t length)
 {
     if (char_ptr == nullptr)

--- a/src/string_util.cc
+++ b/src/string_util.cc
@@ -71,6 +71,16 @@ std::string_view safe_string_view(const char* char_ptr, std::size_t length)
     return std::string_view(char_ptr, end_ptr - char_ptr);
 }
 
+std::string_view safe_string_view(const char* char_ptr)
+{
+    std::string_view result;
+
+    if (char_ptr)
+        result = char_ptr;
+
+    return result;
+}
+
 } // namespace gul17
 
 /* vim:set expandtab softtabstop=4 tabstop=4 shiftwidth=4 textwidth=90 cindent: */

--- a/src/string_util.cc
+++ b/src/string_util.cc
@@ -30,6 +30,26 @@ const std::string_view default_whitespace_characters{ " \t\r\n\a\b\f\v" };
 const std::array<char, 16> hex_digits{
     { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'} };
 
+std::string null_safe_string(const char* char_ptr)
+{
+    std::string result;
+
+    if (char_ptr)
+        result = char_ptr;
+
+    return result;
+}
+
+std::string_view null_safe_string_view(const char* char_ptr)
+{
+    std::string_view result;
+
+    if (char_ptr)
+        result = char_ptr;
+
+    return result;
+}
+
 std::string repeat(std::string_view str, std::size_t n)
 {
     std::string result;
@@ -51,16 +71,6 @@ std::string safe_string(const char* char_ptr, std::size_t length)
     return std::string(char_ptr, end_ptr);
 }
 
-std::string safe_string(const char* char_ptr)
-{
-    std::string result;
-
-    if (char_ptr)
-        result = char_ptr;
-
-    return result;
-}
-
 std::string_view safe_string_view(const char* char_ptr, std::size_t length)
 {
     if (char_ptr == nullptr)
@@ -69,16 +79,6 @@ std::string_view safe_string_view(const char* char_ptr, std::size_t length)
     auto end_ptr = std::find(char_ptr, char_ptr + length, '\0');
 
     return std::string_view(char_ptr, end_ptr - char_ptr);
-}
-
-std::string_view safe_string_view(const char* char_ptr)
-{
-    std::string_view result;
-
-    if (char_ptr)
-        result = char_ptr;
-
-    return result;
 }
 
 } // namespace gul17

--- a/tests/test_string_util.cc
+++ b/tests/test_string_util.cc
@@ -123,7 +123,7 @@ TEST_CASE("repeat()", "[string_util]")
     REQUIRE(repeat("\0\0"s, 2) == "\0\0\0\0"s);
 }
 
-TEST_CASE("safe_string()", "[string_util]")
+TEST_CASE("safe_string(const char*, size_t)", "[string_util]")
 {
     using gul17::safe_string;
 
@@ -133,6 +133,16 @@ TEST_CASE("safe_string()", "[string_util]")
     REQUIRE(safe_string("hello", 10) == "hello");
     REQUIRE(safe_string("hello\0", 6) == "hello");
     REQUIRE(safe_string("hello\0world", 11) == "hello");
+}
+
+TEST_CASE("safe_string(const char*)", "[string_util]")
+{
+    using gul17::safe_string;
+
+    REQUIRE(safe_string(nullptr) == "");
+    REQUIRE(safe_string("") == "");
+    REQUIRE(safe_string("hello") == "hello");
+    REQUIRE(safe_string("hi\0there") == "hi");
 }
 
 TEST_CASE("safe_string_view()", "[string_util]")

--- a/tests/test_string_util.cc
+++ b/tests/test_string_util.cc
@@ -114,6 +114,26 @@ TEST_CASE("hex_string(Container, std::string_view)", "[string_util]")
     REQUIRE(hex_string(sll, "/") == "0000000000000100/ffffffffffffffff/0000000000000000");
 }
 
+TEST_CASE("null_safe_string(const char*)", "[string_util]")
+{
+    using gul17::null_safe_string;
+
+    REQUIRE(null_safe_string(nullptr) == "");
+    REQUIRE(null_safe_string("") == "");
+    REQUIRE(null_safe_string("hello") == "hello");
+    REQUIRE(null_safe_string("hi\0there") == "hi");
+}
+
+TEST_CASE("null_safe_string_view(const char*)", "[string_util]")
+{
+    using gul17::null_safe_string_view;
+
+    REQUIRE(null_safe_string_view(nullptr) == std::string_view{});
+    REQUIRE(null_safe_string_view("") == ""sv);
+    REQUIRE(null_safe_string_view("hello") == "hello"sv);
+    REQUIRE(null_safe_string_view("hi\0there") == "hi"sv);
+}
+
 TEST_CASE("repeat()", "[string_util]")
 {
     REQUIRE(repeat("du", 3) == "dududu");
@@ -135,16 +155,6 @@ TEST_CASE("safe_string(const char*, size_t)", "[string_util]")
     REQUIRE(safe_string("hello\0world", 11) == "hello");
 }
 
-TEST_CASE("safe_string(const char*)", "[string_util]")
-{
-    using gul17::safe_string;
-
-    REQUIRE(safe_string(nullptr) == "");
-    REQUIRE(safe_string("") == "");
-    REQUIRE(safe_string("hello") == "hello");
-    REQUIRE(safe_string("hi\0there") == "hi");
-}
-
 TEST_CASE("safe_string_view(const char*, size_t)", "[string_util]")
 {
     using gul17::safe_string_view;
@@ -157,14 +167,4 @@ TEST_CASE("safe_string_view(const char*, size_t)", "[string_util]")
     REQUIRE(safe_string_view("ABC", 3) == "ABC"sv);
     REQUIRE(safe_string_view("ABC", 4) == "ABC"sv);
     REQUIRE(safe_string_view("AB\0CD", 5) == "AB"sv);
-}
-
-TEST_CASE("safe_string_view(const char*)", "[string_util]")
-{
-    using gul17::safe_string_view;
-
-    REQUIRE(safe_string_view(nullptr) == std::string_view{});
-    REQUIRE(safe_string_view("") == ""sv);
-    REQUIRE(safe_string_view("hello") == "hello"sv);
-    REQUIRE(safe_string_view("hi\0there") == "hi"sv);
 }

--- a/tests/test_string_util.cc
+++ b/tests/test_string_util.cc
@@ -145,7 +145,7 @@ TEST_CASE("safe_string(const char*)", "[string_util]")
     REQUIRE(safe_string("hi\0there") == "hi");
 }
 
-TEST_CASE("safe_string_view()", "[string_util]")
+TEST_CASE("safe_string_view(const char*, size_t)", "[string_util]")
 {
     using gul17::safe_string_view;
 
@@ -157,4 +157,14 @@ TEST_CASE("safe_string_view()", "[string_util]")
     REQUIRE(safe_string_view("ABC", 3) == "ABC"sv);
     REQUIRE(safe_string_view("ABC", 4) == "ABC"sv);
     REQUIRE(safe_string_view("AB\0CD", 5) == "AB"sv);
+}
+
+TEST_CASE("safe_string_view(const char*)", "[string_util]")
+{
+    using gul17::safe_string_view;
+
+    REQUIRE(safe_string_view(nullptr) == std::string_view{});
+    REQUIRE(safe_string_view("") == ""sv);
+    REQUIRE(safe_string_view("hello") == "hello"sv);
+    REQUIRE(safe_string_view("hi\0there") == "hi"sv);
 }


### PR DESCRIPTION
So far, we only provided the overloads `safe_string_view(const char*, size_t)` and `safe_string(const char*, size_t)`, both of which required a length argument. However, sometimes one simply does not know the expected length of a C string, but still wants to be protected from null pointers. Therefore, this PR adds two simple overloads:
```cpp
std::string safe_string(const char*);
std::string_view safe_string_view(const char*);
```