### PR TITLE
join() improvements

### DIFF
--- a/data/doxygen.h
+++ b/data/doxygen.h
@@ -151,6 +151,10 @@ namespace gul17 {
  * - Add gul17::null_safe_string(const char*) and
  *   gul17::null_safe_string_view(const char*). The new functions construct a string or
  *   string_view from a null-terminated C string and are safe against null pointers.
+ * - Allow gul17::join() on ranges of string-like types that do not have a size() member
+ *   function (e.g. const char*).
+ * - Add gul17::join() overloads for joining ranges of elements with a custom string
+ *   conversion function.
  *
  * \subsection V25_4_0 Version 25.4.0
  *

--- a/data/doxygen.h
+++ b/data/doxygen.h
@@ -436,7 +436,8 @@ namespace gul17 {
  * cat(): Efficiently concatenate an arbitrary number of std::strings, C strings,
  *         string_views, or numbers.
  *
- * join(): Concatenate all strings in a range, placing a delimiter between them.
+ * join(): Concatenate a range of elements into a string, placing a delimiter between
+ *      them.
  *
  * repeat(): Repeat a string N times.
  *

--- a/include/gul17/join_split.h
+++ b/include/gul17/join_split.h
@@ -332,12 +332,16 @@ join(const StringContainer& parts, std::string_view glue)
  * Concatenate the strings resulting from calling the given function on each element in a
  * range, placing a delimiter between them.
  *
- * This algorithm iterates exactly once over the range and does not pre-allocate memory.
+ * This algorithm iterates exactly once over the range. To speed up complex joining
+ * operations, string memory can be preallocated via the last parameter.
  *
  * \param begin      Iterator to the first input element
  * \param end        Iterator pointing past the last input element
  * \param glue       String to be put between the string-converted elements
  * \param to_string  Function object to convert the container elements to strings
+ * \param prealloc   Number of bytes to preallocate for the result string. Providing this
+ *                   parameter is not necessary, but it may provide a tiny performance
+ *                   boost. The default is zero (no preallocation).
  *
  * \returns the concatenated string.
  *
@@ -353,13 +357,15 @@ template <typename Iterator, typename ConversionFct,
     std::enable_if_t<std::is_invocable_v<ConversionFct, decltype(*Iterator{})>, bool>
     = true>
 inline std::string
-join(Iterator begin, Iterator end, std::string_view glue, ConversionFct to_string)
+join(Iterator begin, Iterator end, std::string_view glue, ConversionFct to_string,
+     std::size_t prealloc = 0)
 {
     std::string result;
 
     if (begin == end)
         return result; // Return an empty string
 
+    result.reserve(prealloc);
     result += to_string(*begin);
 
     // Iterate over all but the last string
@@ -376,12 +382,15 @@ join(Iterator begin, Iterator end, std::string_view glue, ConversionFct to_strin
  * Concatenate the strings resulting from calling the given function on each element
  * in a range, placing a delimiter between them.
  *
- * This algorithm iterates exactly once over the range and does not pre-allocate
- * memory.
+ * This algorithm iterates exactly once over the range. To speed up complex joining
+ * operations, string memory can be preallocated via the last parameter.
  *
  * \param container  Container of input elements
  * \param glue       String to be put between the string-converted elements
  * \param to_string  Function object to convert the container elements to strings
+ * \param prealloc   Number of bytes to preallocate for the result string. Providing this
+ *                   parameter is not necessary, but it may provide a tiny performance
+ *                   boost. The default is zero (no preallocation).
  *
  * \returns the concatenated string.
  *
@@ -397,9 +406,10 @@ template <typename Container, typename ConversionFct,
     std::enable_if_t<std::is_invocable_v<ConversionFct,
                      decltype(*(std::declval<Container>().cbegin()))>, bool> = true>
 inline std::string
-join(const Container& container, std::string_view glue, ConversionFct to_string)
+join(const Container& container, std::string_view glue, ConversionFct to_string,
+     std::size_t prealloc = 0)
 {
-    return join(container.cbegin(), container.cend(), glue, to_string);
+    return join(container.cbegin(), container.cend(), glue, to_string, prealloc);
 }
 
 /// @}

--- a/include/gul17/join_split.h
+++ b/include/gul17/join_split.h
@@ -306,7 +306,7 @@ join(Iterator begin, Iterator end, std::string_view glue)
 
     result += *begin;
 
-    // Iterate over all but the last string
+    // Iterate over all but the first string
     for (auto it = std::next(begin); it != end; ++it)
     {
         result.append(glue.data(), glue.size());
@@ -409,7 +409,7 @@ join(Iterator begin, Iterator end, std::string_view glue, ConversionFct to_strin
     result.reserve(prealloc);
     result += to_string(*begin);
 
-    // Iterate over all but the last string
+    // Iterate over all but the first element of the range
     for (auto it = std::next(begin); it != end; ++it)
     {
         result += glue;

--- a/include/gul17/join_split.h
+++ b/include/gul17/join_split.h
@@ -235,6 +235,12 @@ split_sv(std::string_view text, std::string_view delimiter,
 /**
  * Concatenate all strings in a range, placing a delimiter between them.
  *
+ * \code{.cpp}
+ * std::vector<std::string> parts = { "one", "two", "three" };
+ * std::string result = join(parts.begin(), parts.end(), "-");
+ * assert(result == "one-two-three");
+ * \endcode
+ *
  * This algorithm iterates twice over the range in order to pre-allocate a string of the
  * correct size.
  *
@@ -293,6 +299,12 @@ join(Iterator begin, Iterator end, std::string_view glue)
 /**
  * Concatenate all strings in a range, placing a delimiter between them.
  *
+ * \code{.cpp}
+ * std::vector<std::string> parts = { "one", "two", "three" };
+ * std::string result = join(parts, "-");
+ * assert(result == "one-two-three");
+ * \endcode
+ *
  * This algorithm iterates twice over the range in order to pre-allocate a string of the
  * correct size.
  *
@@ -331,6 +343,13 @@ join(const StringContainer& parts, std::string_view glue)
 /**
  * Concatenate the strings resulting from calling the given function on each element in a
  * range, placing a delimiter between them.
+ *
+ * \code{.cpp}
+ * std::vector<int> parts = { 1, 2, 3 };
+ * std::string result = join(parts.begin(), parts.end(), "-",
+ *                           [](int i) { return std::to_string(i); });
+ * assert(result == "1-2-3");
+ * \endcode
  *
  * This algorithm iterates exactly once over the range. To speed up complex joining
  * operations, string memory can be preallocated via the last parameter.
@@ -381,6 +400,12 @@ join(Iterator begin, Iterator end, std::string_view glue, ConversionFct to_strin
 /**
  * Concatenate the strings resulting from calling the given function on each element
  * in a range, placing a delimiter between them.
+ *
+ * \code{.cpp}
+ * std::vector<int> parts = { 1, 2, 3 };
+ * std::string result = join(parts, "-", [](int i) { return std::to_string(i); });
+ * assert(result == "1-2-3");
+ * \endcode
  *
  * This algorithm iterates exactly once over the range. To speed up complex joining
  * operations, string memory can be preallocated via the last parameter.

--- a/include/gul17/join_split.h
+++ b/include/gul17/join_split.h
@@ -394,13 +394,14 @@ join(const StringContainer& parts, std::string_view glue)
  *
  * \since GUL version UNRELEASED
  */
-template <typename Iterator, typename ConversionFct,
-    std::enable_if_t<std::is_invocable_v<ConversionFct, decltype(*Iterator{})>, bool>
-    = true>
+template <typename Iterator, typename ConversionFct>
 inline std::string
 join(Iterator begin, Iterator end, std::string_view glue, ConversionFct to_string,
      std::size_t prealloc = 0)
 {
+    static_assert(std::is_invocable_v<ConversionFct, decltype(*begin)>,
+                  "ConversionFct does not accept the element type of the range");
+
     std::string result;
 
     if (begin == end)
@@ -449,9 +450,7 @@ join(Iterator begin, Iterator end, std::string_view glue, ConversionFct to_strin
  *
  * \since GUL version UNRELEASED
  */
-template <typename Container, typename ConversionFct,
-    std::enable_if_t<std::is_invocable_v<ConversionFct,
-                     decltype(*(std::declval<Container>().cbegin()))>, bool> = true>
+template <typename Container, typename ConversionFct>
 inline std::string
 join(const Container& container, std::string_view glue, ConversionFct to_string,
      std::size_t prealloc = 0)

--- a/tests/test_join_split.cc
+++ b/tests/test_join_split.cc
@@ -321,6 +321,57 @@ TEST_CASE("join(container, glue)", "[join_split]")
     }
 }
 
+TEST_CASE("join(begin, end, glue, fct)", "[join_split]")
+{
+    SECTION("vector<unsigned int>, to_string()")
+    {
+        std::vector<unsigned int> input{ 0u, 1u, 2u };
+        auto result = join(input.cbegin(), input.cend(), ", ",
+            [](auto i) { return std::to_string(i); });
+        REQUIRE(result == "0, 1, 2");
+    }
+
+    SECTION("vector<unsigned int>, to_string(), no elements")
+    {
+        std::vector<unsigned int> input{};
+        auto result = join(input.cbegin(), input.cend(), ", ",
+            [](auto i) { return std::to_string(i); });
+        REQUIRE(result == "");
+    }
+
+    SECTION("vector<const char*>, custom decorator fct")
+    {
+        std::vector<const char*> input{ "uno", "due", "tre" };
+        auto result = join(input.cbegin(), input.cend(), "*",
+            [](const char* c) { return "<" + std::string{ c } + ">"; });
+        REQUIRE(result == "<uno>*<due>*<tre>");
+    }
+}
+
+TEST_CASE("join(container, glue, fct)", "[join_split]")
+{
+    SECTION("vector<unsigned int>, to_string()")
+    {
+        std::vector<unsigned int> input{ 0u, 1u, 2u };
+        auto result = join(input, ", ", [](auto i) { return std::to_string(i); });
+        REQUIRE(result == "0, 1, 2");
+    }
+
+    SECTION("vector<unsigned int>, to_string(), no elements")
+    {
+        std::vector<unsigned int> input{};
+        auto result = join(input, ", ", [](auto i) { return std::to_string(i); });
+        REQUIRE(result == "");
+    }
+
+    SECTION("vector<const char*>, custom decorator fct")
+    {
+        std::vector<const char*> input{ "uno", "due", "tre" };
+        auto result = join(
+            input, "*", [](const char* c) { return "<" + std::string{ c } + ">"; });
+        REQUIRE(result == "<uno>*<due>*<tre>");
+    }
+}
 
 TEST_CASE("join(split())", "[join_split]")
 {

--- a/tests/test_join_split.cc
+++ b/tests/test_join_split.cc
@@ -20,6 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include <deque>
 #include <forward_list>
 #include <list>
 #include <queue>
@@ -283,6 +284,18 @@ TEST_CASE("join(begin, end, glue)", "[join_split]")
         list = { "forty"sv, "two"sv };
         REQUIRE(join(list.cbegin(), list.cend() , "-") == "forty-two");
     }
+
+    SECTION("std::deque<const char*>")
+    {
+        auto deque = std::deque<const char*>{};
+        REQUIRE(join(deque.cbegin(), deque.cend(), "::") == "");
+
+        deque = { "one", "two" };
+        REQUIRE(join(deque.cbegin(), deque.cend(), "::") == "one::two");
+
+        deque = { "alpha", "bravo", "charlie" };
+        REQUIRE(join(deque.cbegin(), deque.cend() , "::") == "alpha::bravo::charlie");
+    }
 }
 
 TEST_CASE("join(container, glue)", "[join_split]")
@@ -318,6 +331,25 @@ TEST_CASE("join(container, glue)", "[join_split]")
         list.emplace_front("forty");
         REQUIRE(join(list, "-") == "forty-two");
         REQUIRE(join(list.begin(), list.end(), "-") == "forty-two");
+    }
+
+    SECTION("deque<const char*>")
+    {
+        auto deque = std::deque<const char*>{};
+        REQUIRE(join(deque, "::") == "");
+        REQUIRE(join(deque.begin(), deque.end(), "::") == "");
+
+        deque.emplace_back("one");
+        REQUIRE(join(deque, "::") == "one");
+        REQUIRE(join(deque.begin(), deque.end(), "::") == "one");
+
+        deque.emplace_back("two");
+        REQUIRE(join(deque, "::") == "one::two");
+        REQUIRE(join(deque.begin(), deque.end(), "::") == "one::two");
+
+        deque.emplace_back("three");
+        REQUIRE(join(deque, "::") == "one::two::three");
+        REQUIRE(join(deque.begin(), deque.end(), "::") == "one::two::three");
     }
 }
 

--- a/tests/test_join_split.cc
+++ b/tests/test_join_split.cc
@@ -321,54 +321,82 @@ TEST_CASE("join(container, glue)", "[join_split]")
     }
 }
 
-TEST_CASE("join(begin, end, glue, fct)", "[join_split]")
+TEST_CASE("join(begin, end, glue, fct [, prealloc])", "[join_split]")
 {
     SECTION("vector<unsigned int>, to_string()")
     {
         std::vector<unsigned int> input{ 0u, 1u, 2u };
+
         auto result = join(input.cbegin(), input.cend(), ", ",
             [](auto i) { return std::to_string(i); });
+        REQUIRE(result == "0, 1, 2");
+
+        result = join(input.cbegin(), input.cend(), ", ",
+            [](auto i) { return std::to_string(i); }, 128u);
         REQUIRE(result == "0, 1, 2");
     }
 
     SECTION("vector<unsigned int>, to_string(), no elements")
     {
         std::vector<unsigned int> input{};
+
         auto result = join(input.cbegin(), input.cend(), ", ",
             [](auto i) { return std::to_string(i); });
+        REQUIRE(result == "");
+
+        result = join(input.cbegin(), input.cend(), ", ",
+            [](auto i) { return std::to_string(i); }, 256u);
         REQUIRE(result == "");
     }
 
     SECTION("vector<const char*>, custom decorator fct")
     {
         std::vector<const char*> input{ "uno", "due", "tre" };
+
         auto result = join(input.cbegin(), input.cend(), "*",
             [](const char* c) { return "<" + std::string{ c } + ">"; });
+        REQUIRE(result == "<uno>*<due>*<tre>");
+
+        result = join(input.cbegin(), input.cend(), "*",
+            [](const char* c) { return "<" + std::string{ c } + ">"; }, 6u);
         REQUIRE(result == "<uno>*<due>*<tre>");
     }
 }
 
-TEST_CASE("join(container, glue, fct)", "[join_split]")
+TEST_CASE("join(container, glue, fct [, prealloc])", "[join_split]")
 {
     SECTION("vector<unsigned int>, to_string()")
     {
         std::vector<unsigned int> input{ 0u, 1u, 2u };
+
         auto result = join(input, ", ", [](auto i) { return std::to_string(i); });
+        REQUIRE(result == "0, 1, 2");
+
+        result = join(input, ", ", [](auto i) { return std::to_string(i); }, 128u);
         REQUIRE(result == "0, 1, 2");
     }
 
     SECTION("vector<unsigned int>, to_string(), no elements")
     {
         std::vector<unsigned int> input{};
+
         auto result = join(input, ", ", [](auto i) { return std::to_string(i); });
+        REQUIRE(result == "");
+
+        result = join(input, ", ", [](auto i) { return std::to_string(i); }, 56u);
         REQUIRE(result == "");
     }
 
     SECTION("vector<const char*>, custom decorator fct")
     {
         std::vector<const char*> input{ "uno", "due", "tre" };
+
         auto result = join(
             input, "*", [](const char* c) { return "<" + std::string{ c } + ">"; });
+        REQUIRE(result == "<uno>*<due>*<tre>");
+
+        result = join(
+            input, "*", [](const char* c) { return "<" + std::string{ c } + ">"; }, 8u);
         REQUIRE(result == "<uno>*<due>*<tre>");
     }
 }

--- a/tests/test_join_split.cc
+++ b/tests/test_join_split.cc
@@ -36,7 +36,7 @@
 #include "gul17/join_split.h"
 #include "gul17/SmallVector.h"
 
-using namespace std::literals::string_literals;
+using namespace std::literals;
 using gul17::SmallVector;
 using gul17::split;
 using gul17::split_sv;
@@ -240,30 +240,87 @@ TEMPLATE_TEST_CASE("split_sv() with associative containers", "[join_split]",
     REQUIRE(std::find(x.begin(), x.end(), "World") != x.end());
 }
 
-TEST_CASE("join()", "[join_split]")
+TEST_CASE("join(begin, end, glue)", "[join_split]")
 {
-    REQUIRE(join(std::vector<std::string>{ }, "lalala") == "");
-    REQUIRE(join(std::vector<std::string>{ { "" } }, "lalala") == "");
-    REQUIRE(join(std::vector<std::string>{ { "xyzzy" } }, "lalala") == "xyzzy");
-    REQUIRE(join(std::vector<std::string>{ { "A" }, { "B" } }, "lalala") == "AlalalaB");
+    SECTION("vector<string>")
+    {
+        auto vec = std::vector<std::string>{};
+        REQUIRE(join(vec.cbegin(), vec.cend(), "lalala") == "");
 
-    REQUIRE(join(std::vector<std::string_view>{ }, "lalala") == "");
-    REQUIRE(join(std::vector<std::string_view>{ { "" } }, "lalala") == "");
-    REQUIRE(join(std::vector<std::string_view>{ { "xyzzy" } }, "lalala") == "xyzzy"s);
-    REQUIRE(join(std::vector<std::string_view>{ { "A" }, { "B" } }, "lalala") == "AlalalaB");
+        vec = { ""s };
+        REQUIRE(join(vec.cbegin(), vec.cend(), "lalala") == "");
 
-    std::forward_list<std::string_view> list;
-    REQUIRE(join(list, "-") == "");
-    REQUIRE(join(list.begin(), list.end(), "-") == "");
+        vec = { "xyzzy"s };
+        REQUIRE(join(vec.cbegin(), vec.cend() , "lalala") == "xyzzy");
 
-    list.emplace_front("two");
-    REQUIRE(join(list, "-") == "two");
-    REQUIRE(join(list.begin(), list.end(), "-") == "two");
+        vec = { "A"s, "B"s };
+        REQUIRE(join(vec.cbegin(), vec.cend(), "lalala") == "AlalalaB");
+    }
 
-    list.emplace_front("forty");
-    REQUIRE(join(list, "-") == "forty-two");
-    REQUIRE(join(list.begin(), list.end(), "-") == "forty-two");
+    SECTION("vector<string_view>")
+    {
+        auto vec = std::vector<std::string_view>{};
+        REQUIRE(join(vec.cbegin(), vec.cend(), "lalala") == "");
+
+        vec = { ""sv };
+        REQUIRE(join(vec.cbegin(), vec.cend(), "lalala") == "");
+
+        vec = { "xyzzy"sv };
+        REQUIRE(join(vec.cbegin(), vec.cend() , "lalala") == "xyzzy");
+
+        vec = { "A"sv, "B"sv };
+        REQUIRE(join(vec.cbegin(), vec.cend(), "lalala") == "AlalalaB");
+    }
+
+    SECTION("std::forward_list<string_view>")
+    {
+        auto list = std::forward_list<std::string_view>{};
+        REQUIRE(join(list.cbegin(), list.cend(), "-") == "");
+
+        list = { "two"sv };
+        REQUIRE(join(list.cbegin(), list.cend(), "-") == "two");
+
+        list = { "forty"sv, "two"sv };
+        REQUIRE(join(list.cbegin(), list.cend() , "-") == "forty-two");
+    }
 }
+
+TEST_CASE("join(container, glue)", "[join_split]")
+{
+    SECTION("vector<string>")
+    {
+        REQUIRE(join(std::vector<std::string>{ }, "lalala") == "");
+        REQUIRE(join(std::vector<std::string>{ { "" } }, "lalala") == "");
+        REQUIRE(join(std::vector<std::string>{ { "xyzzy" } }, "lalala") == "xyzzy");
+        REQUIRE(join(std::vector<std::string>{ { "A" }, { "B" } }, "lalala")
+                == "AlalalaB");
+    }
+
+    SECTION("vector<string_view>")
+    {
+        REQUIRE(join(std::vector<std::string_view>{ }, "lalala") == "");
+        REQUIRE(join(std::vector<std::string_view>{ { "" } }, "lalala") == "");
+        REQUIRE(join(std::vector<std::string_view>{ { "xyzzy" } }, "lalala") == "xyzzy"s);
+        REQUIRE(join(std::vector<std::string_view>{ { "A" }, { "B" } }, "lalala")
+                == "AlalalaB");
+    }
+
+    SECTION("forward_list<string_view>")
+    {
+        std::forward_list<std::string_view> list;
+        REQUIRE(join(list, "-") == "");
+        REQUIRE(join(list.begin(), list.end(), "-") == "");
+
+        list.emplace_front("two");
+        REQUIRE(join(list, "-") == "two");
+        REQUIRE(join(list.begin(), list.end(), "-") == "two");
+
+        list.emplace_front("forty");
+        REQUIRE(join(list, "-") == "forty-two");
+        REQUIRE(join(list.begin(), list.end(), "-") == "forty-two");
+    }
+}
+
 
 TEST_CASE("join(split())", "[join_split]")
 {


### PR DESCRIPTION
This PR adds a few improvements to the `join()` family of functions:
- Allow joining ranges of string-like elements where the element type does not have a `.size()` member function. Most importantly, this finally allows joining a `vector<const char*>`.
- Allow joining ranges of arbitrary element types using a custom string-conversion function. For example:
    ```cpp
    std::vector<int> parts = { 1, 2, 3 };
    std::string result = join(parts, "-", [](int i) { return std::to_string(i); });
    assert(result == "1-2-3");
    ```
- Enhance Doxygen documentation with usage examples.