### PR TITLE
Improve GUL14 migration script

### DIFF
--- a/tools/migrate_gul14_to_gul17.bash
+++ b/tools/migrate_gul14_to_gul17.bash
@@ -35,6 +35,10 @@ gul17_shared = libgul_shared_dep
 EOT
 }
 
+handle_control_file() {
+    sed -i -E -e 's/dev-doocs-libgul14/gul17-dev/g' "$1"
+}
+
 handle_meson_file() {
     sed -i -E \
         -e 's/(dependency\s*\(\s*)'"'libgul14'/\1'gul17'"'/g' \
@@ -84,6 +88,11 @@ for dir in "$@"; do
         done < <( find "${dir}" \
             \( -path "./${dir}/build*" -o -path "./${dir}/debian" -o -path "./${dir}/subprojects" \) -prune \
             -o \( \( -name "*.h" -o -name "*.hpp" -o -name "*.cc" -o -name "*.cpp" \) -print0 \) )
+
+        # Debian control file
+        if [ -f "${dir}/debian/control" ]; then
+            handle_control_file "${dir}/debian/control"
+        fi
 
         # wrap file
         if [ -d "${dir}/subprojects" ]; then

--- a/tools/migrate_gul14_to_gul17.bash
+++ b/tools/migrate_gul14_to_gul17.bash
@@ -23,7 +23,7 @@ fi
 handle_meson_file() {
     sed -i -E \
         -e 's/(dependency\s*\(\s*)'"'libgul14'/\1'gul17'"'/g' \
-        -e 's/\[\s*'"'libgul14'"'\s*,\s*'"'libgul_dep'"'\s*\]/['"'gul17', 'gul17_dep']"'/g' \
+        -e "s/'libgul14'/'gul17'/g" \
         "$1"
 }
 

--- a/tools/migrate_gul14_to_gul17.bash
+++ b/tools/migrate_gul14_to_gul17.bash
@@ -30,8 +30,6 @@ revision = main
 [provide]
 dependency_names = gul17
 gul17 = libgul_dep
-gul17_static = libgul_static_dep
-gul17_shared = libgul_shared_dep
 EOT
 }
 

--- a/tools/migrate_gul14_to_gul17.bash
+++ b/tools/migrate_gul14_to_gul17.bash
@@ -20,6 +20,21 @@ EOT
 exit 1
 fi
 
+create_gul17_wrap_file() {
+    cat > "$1" << EOT
+[wrap-git]
+directory = gul17
+url = https://github.com/gul-cpp/gul17.git
+revision = main
+
+[provide]
+dependency_names = gul17
+gul17 = libgul_dep
+gul17_static = libgul_static_dep
+gul17_shared = libgul_shared_dep
+EOT
+}
+
 handle_meson_file() {
     sed -i -E \
         -e 's/(dependency\s*\(\s*)'"'libgul14'/\1'gul17'"'/g' \
@@ -69,6 +84,14 @@ for dir in "$@"; do
         done < <( find "${dir}" \
             \( -path "./${dir}/build*" -o -path "./${dir}/debian" -o -path "./${dir}/subprojects" \) -prune \
             -o \( \( -name "*.h" -o -name "*.hpp" -o -name "*.cc" -o -name "*.cpp" \) -print0 \) )
+
+        # wrap file
+        if [ -d "${dir}/subprojects" ]; then
+            if [ ! -e "${dir}/subprojects/gul17.wrap" ]; then
+                echo "Creating gul17.wrap file in ${dir}/subprojects"
+                create_gul17_wrap_file "${dir}/subprojects/gul17.wrap"
+            fi
+        fi
 
     fi
     if [ "${mos_found}" = true ]; then


### PR DESCRIPTION
These are a few improvements for the GUL14-to-GUL17 migration script. Among other things, the PR

- adds a gul17.wrap file if there is a subprojects/ folder,
- fixes the names of package dependencies in the Debian `control` file, and
- corrects some replacements inside the `meson.build` files.