### PR TITLE
GUL14 migration: Preserve gul14/catch.h includes

### DIFF
--- a/tools/migrate_gul14_to_gul17.bash
+++ b/tools/migrate_gul14_to_gul17.bash
@@ -7,7 +7,8 @@ Usage: $0 <directories>
 
 This script will update C++ source files and meson.build files in the
 given directories to migrate from GUL14 to GUL17. The given directories
-are searched recursively.
+should be the root directories of the projects, i.e. those that contain
+the main meson.build file, the debian/ directory, and the src/ folder.
 
 The migration happens in place, so make sure to have a backup (or a
 recent git commit) of your files.

--- a/tools/migrate_gul14_to_gul17.bash
+++ b/tools/migrate_gul14_to_gul17.bash
@@ -38,6 +38,10 @@ handle_control_file() {
     sed -i -E -e 's/dev-doocs-libgul14/gul17-dev/g' "$1"
 }
 
+handle_gitlab_ci_file() {
+    sed -i -E -e 's/dev-doocs-libgul14/gul17-dev/g' "$1"
+}
+
 handle_meson_file() {
     sed -i -E \
         -e 's/(dependency\s*\(\s*)'"'libgul14'/\1'gul17'"'/g' \
@@ -93,6 +97,11 @@ for dir in "$@"; do
         # Debian control file
         if [ -f "${dir}/debian/control" ]; then
             handle_control_file "${dir}/debian/control"
+        fi
+
+        # Gitlab CI file
+        if [ -f "${dir}/.gitlab-ci.yml" ]; then
+            handle_gitlab_ci_file "${dir}/.gitlab-ci.yml"
         fi
 
         # wrap file

--- a/tools/migrate_gul14_to_gul17.bash
+++ b/tools/migrate_gul14_to_gul17.bash
@@ -50,6 +50,7 @@ handle_source_file() {
         -e 's/(#include\s*)["<]gul17\/string_view.h[">]/\1<string_view>/g' \
         -e 's/(#include\s*)["<]gul17\/optional.h[">]/\1<optional>/g' \
         -e 's/(#include\s*)["<]gul17\/variant.h[">]/\1<variant>/g' \
+        -e 's/(#include\s*["<])gul17\/catch.h([">])/\1gul14\/catch.h\2/g' \
         -e 's/gul14::/gul17::/g' \
         -e 's/gul17::string_view/std::string_view/g' \
         -e 's/gul17::optional/std::optional/g' \


### PR DESCRIPTION
GUL17 does not bundle a header-only Catch2 include file anymore, so some manual work is required to migrate a project to Catch2v3. This is out of the scope of the GUL14 migration script. The best way of dealing with this is, arguably, to keep including the header that is bundled with GUL14.