### PR TITLE
Fix compiling on MacOS

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -42,6 +42,9 @@ version_cc = configure_file(
 so_version = lib_version_num
 
 add_cpp_args = [ ]
+if build_machine.system() == 'darwin'
+    add_cpp_args += [ '-U_LIBCPP_ENABLE_ASSERTIONS' ]
+endif
 if meson.get_compiler('cpp').has_argument('-Wshadow') # msvc doesnt have
     add_cpp_args += [ '-Wshadow' ]
 endif


### PR DESCRIPTION
**[why]**
For a time we got warnings, after the latest `xcode` update they turned into errors, of the form:

```
error "_LIBCPP_ENABLE_ASSERTIONS has been removed, please use _LIBCPP_HARDENING_MODE instead"
```

**[how]**
Turning LIBCPP assertions off as suggested by still open Issue in Meson:
https://www.github.com/mesonbuild/meson/issues/13978

Suggested-by: Lars Froehlich <lars.froehlich@desy.de>