### PR TITLE
SmallVector: Add missing include and std prefix

### DIFF
--- a/include/gul17/SmallVector.h
+++ b/include/gul17/SmallVector.h
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cstdint>
 #include <initializer_list>
 #include <iterator>
 #include <limits>
@@ -274,7 +275,7 @@ public:
     /// \copydoc ValueType
     using value_type = ValueType;
     /// Unsigned integer type for indexing, number of elements, capacity
-    using SizeType = uint32_t;
+    using SizeType = std::uint32_t;
     /// \copydoc SizeType
     using size_type = SizeType;
     /// Signed integer type for the difference of two iterators


### PR DESCRIPTION
## Why
The compilation fails with:
> In file included from doocs-clientlib/src/EqAdr.cc:29:
> subprojects/gul17/include/gul17/SmallVector.h:277:22: error: 'uint32_t' does not name a type [-Wtemplate-body]
>   277 |     using SizeType = uint32_t;
>       |                      ^~~~~~~~
> subprojects/gul17/include/gul17/SmallVector.h:32:1: note: 'uint32_t' is defined in header '<cstdint>'; this is probably fixable by adding '#include <cstdint>'
> ---8<---