### PR TITLE
Enhancement: Add parsers and serializers for JSON, YAML and XML

### DIFF
--- a/include/gul17/DataTree.h
+++ b/include/gul17/DataTree.h
@@ -31,11 +31,47 @@
 
 namespace gul17 {
 
+/**
+ * \addtogroup DataTree_h gul17/DataTree.h
+ * \brief A hierarchical data structure for representing various data types.
+ * @{
+ */
+
+/**
+ * A hierarchical data structure that can represent various data types including
+ * null, boolean, number, string, array, and object.
+ *
+ * The DataTree class can be used to create, manipulate, and access data in a
+ * tree-like structure. It supports dynamic typing and can hold different types
+ * of data at each node.
+ * It can be used to represent data formats such as JSON, YAML, or XML.
+ *
+ * \code
+ * // Create a data tree object
+ * DataTree tree;
+ *
+ * tree["foo"] = "bar";          // String
+ * tree["answer"] = 42;          // Number
+ * tree["is_valid"] = true;     // Boolean
+ * tree["items"] = DataTree::array{1, 2, 3}; // Array
+ * tree["config"] = DataTree::object{ {"key1", "value1"}, {"key2", 42} }; // Object
+ *
+ * tree["items"].push_back(4);  // Add an element to the array
+ * tree["config"]["key3"] = 3.14; // Add a key-value pair to the object
+ * \endcode
+ *
+ * \since GUL version x.y.z
+ */
 class DataTree
 {
 public:
+    // Type definitions
+
+    /// Type of an object (key-value pairs)
     using Object = std::unordered_map<std::string, DataTree>;
+    /// Type of an array (list of values)
     using Array = std::vector<DataTree>;
+    /// Underlying variant type to hold different data types
     using Value = std::variant<
         std::nullptr_t,    // null
         bool,              // boolean
@@ -47,45 +83,167 @@ public:
     >;
 
     // Constructors
+
+    /**
+     * Create an empty DataTree object (default to an empty object).
+     */
     DataTree() : value_(Object()) {}  // default to an empty object
+
+    /**
+     * Create a DataTree object holding a null value.
+     */
     DataTree(std::nullptr_t) : value_(nullptr) {}
+
+    /**
+     * Create a DataTree object holding a boolean value.
+     */
     DataTree(bool b) : value_(b) {}
+
+    /**
+     * Create a DataTree object holding an integer value.
+     */
     DataTree(int i) : value_(i) {}
+
+    /**
+     * Create a DataTree object holding a floating-point value.
+     */
     DataTree(double d) : value_(d) {}
+
+    /**
+     * Create a DataTree object holding a string value.
+     */
     DataTree(const std::string& s) : value_(s) {}
+
+    /**
+     * Create a DataTree object holding a C-style string value.
+     */
     DataTree(const char* s) : value_(std::string(s)) {}
+
+    /**
+     * Create a DataTree object holding an array value.
+     */
     DataTree(const Array& a) : value_(a) {}
+
+    /**
+     * Create a DataTree object holding an object value.
+     */
     DataTree(const Object& o) : value_(o) {}
 
     // Factory methods
+
+    /**
+     * Create a DataTree object representing a null value.
+     */
+    static DataTree make_null() { return DataTree(nullptr); }
+
+    /**
+     * Create a DataTree object representing an empty array.
+     */
     static DataTree make_array() { return DataTree(Array{}); }
+
+    /**
+     * Create a DataTree object representing an empty object.
+     */
     static DataTree make_object() { return DataTree(Object{}); }
 
     // Move constructors
+
+    /**
+     * Create a DataTree object by moving an array into it.
+     */
     DataTree(Array&& a) : value_(std::move(a)) {}
+
+    /**
+     * Create a DataTree object by moving an object into it.
+     */
     DataTree(Object&& o) : value_(std::move(o)) {}
+
+    /**
+     * Create a DataTree object by moving a string into it.
+     */
     DataTree(std::string&& s) : value_(std::move(s)) {}
 
-    // Copy constructor
-    DataTree(const DataTree& other) = default;
-
-    // Move constructor
+    /**
+     * Move another DataTree object into this one.
+     */
     DataTree(DataTree&& other) = default;
 
+    // Copy constructor
+
+    /**
+     * Create a copy of another DataTree object.
+     */
+    DataTree(const DataTree& other) = default;
+
     // Assignment operators
+
+    /**
+     * Assign another DataTree object to this one.
+     */
     DataTree& operator=(const DataTree& other) = default;
+
+    /**
+     * Move-assign another DataTree object to this one.
+     */
     DataTree& operator=(DataTree&& other) = default;
 
     // Type checking
+
+    /**
+     * Check if the DataTree holds a null value.
+     * \return True if the DataTree is null, false otherwise.
+     */
     bool is_null() const    { return std::holds_alternative<std::nullptr_t>(value_); }
+
+    /**
+     * Check if the DataTree holds a boolean value.
+     * \return True if the DataTree is boolean, false otherwise.
+     */
     bool is_boolean() const { return std::holds_alternative<bool>(value_); }
+
+    /**
+     * Check if the DataTree holds an integer value.
+     * \return True if the DataTree is integer, false otherwise.
+     */
     bool is_int() const     { return std::holds_alternative<int>(value_); }
+
+    /**
+     * Check if the DataTree holds a floating-point value.
+     * \return True if the DataTree is floating-point, false otherwise.
+     */
     bool is_double() const  { return std::holds_alternative<double>(value_); }
+
+    /**
+     * Check if the DataTree holds a numeric value.
+     * \return True if the DataTree is numeric (integer or floating-point), false otherwise.
+     */
     bool is_number() const  { return is_int() || is_double(); }
+
+    /**
+     * Check if the DataTree holds a string value.
+     * \return True if the DataTree is string, false otherwise.
+     */
     bool is_string() const  { return std::holds_alternative<std::string>(value_); }
+
+    /**
+     * Check if the DataTree holds an array value.
+     * \return True if the DataTree is array, false otherwise.
+     */
     bool is_array() const   { return std::holds_alternative<Array>(value_); }
+
+    /**
+     * Check if the DataTree holds an object value.
+     * \return True if the DataTree is object, false otherwise.
+     */
     bool is_object() const  { return std::holds_alternative<Object>(value_); }
 
+    /**
+     * Check if the DataTree is empty.
+     * A DataTree is considered empty if it is null, or if it is a string, array,
+     * or object that contains no elements.
+     *
+     * \return True if the DataTree is empty, false otherwise.
+     */
     bool is_empty() const
     {
         if (is_null()) return true;
@@ -95,6 +253,12 @@ public:
         return false;
     }
 
+    /**
+     * Check if the object contains the specified key.
+     * Throws a std::runtime_error if the DataTree is not an object.
+     * \param key The key to check for.
+     * \return True if the key exists, false otherwise.
+     */
     bool has_key(const std::string& key) const
     {
         if (!is_object())
@@ -103,6 +267,11 @@ public:
         return obj.find(key) != obj.end();
     }
 
+    /**
+     * Get the size of the array or object.
+     * Throws a std::runtime_error if the DataTree is neither an array nor an object.
+     * \return The number of elements in the array or object.
+     */
     size_t size() const
     {
         if (is_array())
@@ -113,6 +282,11 @@ public:
             throw std::runtime_error("DataTree is neither array nor object");
     }
 
+    /**
+     * Add an element to the end of the array.
+     * Throws a std::runtime_error if the DataTree is not an array.
+     * \param val The value to add.
+     */
     void push_back(const DataTree& val)
     {
         if (!is_array())
@@ -120,6 +294,11 @@ public:
         std::get<Array>(value_).push_back(val);
     }
 
+    /**
+     * Add an element to the end of the array by moving it.
+     * Throws a std::runtime_error if the DataTree is not an array.
+     * \param val The value to add.
+     */
     void emplace_back(DataTree&& val)
     {
         if (!is_array())
@@ -127,6 +306,12 @@ public:
         std::get<Array>(value_).emplace_back(std::move(val));
     }
 
+    /**
+     * Insert a key-value pair into the object.
+     * Throws a std::runtime_error if the DataTree is not an object.
+     * \param key The key to insert.
+     * \param val The value to insert.
+     */
     void insert(const std::string& key, const DataTree& val)
     {
         if (!is_object())
@@ -134,6 +319,13 @@ public:
         std::get<Object>(value_)[key] = val;
     }
 
+    /**
+     * Insert a value into the array at the specified index.
+     * Throws a std::runtime_error if the DataTree is not an array.
+     * Throws a std::out_of_range if the index is out of bounds.
+     * \param index The index at which to insert the value.
+     * \param val   The value to insert.
+     */
     void insert(size_t index, const DataTree& val)
     {
         if (!is_array())
@@ -144,6 +336,10 @@ public:
         arr.insert(arr.begin() + index, val);
     }
 
+    /**
+     * Clear all elements from the array or object.
+     * Throws a std::runtime_error if the DataTree is neither an array nor an object.
+     */
     void clear()
     {
         if (is_array())
@@ -159,6 +355,12 @@ public:
     using const_iterator = const DataTree*;
 
     // Iterators
+
+    /**
+     * Return an iterator to the beginning of the array.
+     * Throws a std::runtime_error if the DataTree is not an array.
+     * \return An iterator to the first element.
+     */
     iterator begin()
     {
         if (!is_array())
@@ -167,6 +369,11 @@ public:
         return arr.data();
     }
 
+    /**
+     * Return an iterator to the end of the array.
+     * Throws a std::runtime_error if the DataTree is not an array.
+     * \return An iterator to the last element.
+     */
     iterator end()
     {
         if (!is_array())
@@ -175,13 +382,45 @@ public:
         return arr.data() + arr.size();
     }
 
+    /**
+     * Return a const iterator to the beginning of the array.
+     * Throws a std::runtime_error if the DataTree is not an array.
+     * \return A const iterator to the first element.
+     */
     const_iterator cbegin() const { return const_cast<DataTree*>(this)->begin(); }
+
+    /**
+     * Return a const iterator to the end of the array.
+     * Throws a std::runtime_error if the DataTree is not an array.
+     * \return A const iterator to the last element.
+     */
     const_iterator cend() const { return const_cast<DataTree*>(this)->end(); }
 
+    /**
+     * Return a const iterator to the beginning of the array.
+     * Throws a std::runtime_error if the DataTree is not an array.
+     * \return A const iterator to the first element.
+     */
     const_iterator begin() const { return cbegin(); }
+
+    /**
+     * Return a const iterator to the end of the array.
+     * Throws a std::runtime_error if the DataTree is not an array.
+     * \return A const iterator to the last element.
+     */
     const_iterator end() const { return cend(); }
 
     // Accessors with bounds checking
+
+    /**
+     * Get a reference to the value associated with the specified key in the object,
+     * or the value at the specified index in the array.
+     * Throws a std::runtime_error if the DataTree is not an object/array.
+     * Throws a std::out_of_range if the key/index does not exist.
+     * \param key   The key to look up in the object.
+     * \param index The index to look up in the array.
+     * \return A reference to the corresponding DataTree value.
+     */
     DataTree& at(const std::string& key)
     {
         if (!is_object())
@@ -192,10 +431,26 @@ public:
             throw std::out_of_range("Key not found in object: " + key);
         return const_cast<DataTree&>(it->second);
     }
+
+    /**
+     * Get a const reference to the value associated with the specified key in the object.
+     * Throws a std::runtime_error if the DataTree is not an object.
+     * Throws a std::out_of_range if the key does not exist.
+     * \param key The key to look up in the object.
+     * \return A const reference to the corresponding DataTree value.
+     */
     const DataTree& at(const std::string& key) const
     {
         return const_cast<DataTree*>(this)->at(key);
     }
+
+    /**
+     * Get a reference to the value at the specified index in the array.
+     * Throws a std::runtime_error if the DataTree is not an array.
+     * Throws a std::out_of_range if the index is out of bounds.
+     * \param index The index to look up in the array.
+     * \return A reference to the corresponding DataTree value.
+     */
     DataTree& at(size_t index)
     {
         if (!is_array())
@@ -205,33 +460,80 @@ public:
             throw std::out_of_range("Index out of range: " + std::to_string(index));
         return const_cast<DataTree&>(arr[index]);
     }
+
+    /**
+     * Get a const reference to the value at the specified index in the array.
+     * Throws a std::runtime_error if the DataTree is not an array.
+     * Throws a std::out_of_range if the index is out of bounds.
+     * \param index The index to look up in the array.
+     * \return A const reference to the corresponding DataTree value.
+     */
     const DataTree& at(size_t index) const
     {
         return const_cast<DataTree*>(this)->at(index);
     }
 
     // Operator[] without bounds checking
+
+    /**
+     * Get a reference to the value associated with the specified key in the object,
+     * or the value at the specified index in the array.
+     * Throws a std::runtime_error if the DataTree is not an object/array.
+     * \param key   The key to look up in the object.
+     * \param index The index to look up in the array.
+     * \return A reference to the corresponding DataTree value.
+     */
     DataTree& operator[](const std::string& key)
     {
         if (!is_object())
             throw std::runtime_error("DataTree is not an object");
         return std::get<Object>(value_)[key];
     }
+
+    /**
+     * Get a const reference to the value associated with the specified key in the object,
+     * or the value at the specified index in the array.
+     * Throws a std::runtime_error if the DataTree is not an object/array.
+     * \param key   The key to look up in the object.
+     * \param index The index to look up in the array.
+     * \return A const reference to the corresponding DataTree value.
+     */
     const DataTree& operator[](const std::string& key) const
     {
         return (*const_cast<DataTree*>(this))[key];
     }
+
+    /**
+     * Get a reference to the value at the specified index in the array.
+     * Throws a std::runtime_error if the DataTree is not an array.
+     * \param index The index to look up in the array.
+     * \return A reference to the corresponding DataTree value.
+     */
     DataTree& operator[](size_t index)
     {
         if (!is_array())
             throw std::runtime_error("DataTree is not an array");
         return std::get<Array>(value_)[index];
     }
+
+    /**
+     * Get a const reference to the value at the specified index in the array.
+     * Throws a std::runtime_error if the DataTree is not an array.
+     * \param index The index to look up in the array.
+     * \return A reference to the corresponding DataTree value.
+     */
     const DataTree& operator[](size_t index) const
     {
         return (*const_cast<DataTree*>(this))[index];
     }
 
+    // Type checking for template types
+
+    /**
+     * Check if the DataTree holds a value of type T.
+     * \tparam T The type to check against.
+     * \return True if the DataTree holds a value of type T, false otherwise.
+     */
     template<typename T>
     bool is() const
     {
@@ -267,6 +569,23 @@ public:
     }
 
     // Conversion
+
+    /**
+     * Convert the DataTree to the specified type T.
+     * Throws a std::bad_variant_access if the conversion is not possible.
+     * \tparam T The type to convert to.
+     * \return The converted value.
+     *
+     * \code
+     * DataTree tree = 42;
+     * int value = tree.as<int>(); // value == 42
+     * \endcode
+     *
+     * Note that implicit conversions are supported for some types:
+     * - int to double
+     * - boolean to int
+     * - int/double/boolean/null to string
+     */
     template<typename T>
     T as() const
     {
@@ -277,11 +596,11 @@ public:
         else if constexpr (std::is_same_v<T, bool>)
         {
             if (is_boolean()) return std::get<bool>(value_);
+            if (is_int()) return std::get<int>(value_) != 0;
         }
         else if constexpr (std::is_same_v<T, int>)
         {
             if (is_int()) return std::get<int>(value_);
-            if (is_double()) return static_cast<int>(std::get<double>(value_));
             if (is_boolean()) return static_cast<int>(std::get<bool>(value_));
         }
         else if constexpr (std::is_same_v<T, double>)
@@ -296,7 +615,7 @@ public:
             if (is_double()) return std::to_string(std::get<double>(value_));
             if (is_boolean()) return std::get<bool>(value_) ? "true" : "false";
             if (is_null()) return "null";
-            // Add conversion logic for other types to string if needed
+            // TODO: Add conversion logic for other types to string if needed
         }
         else if constexpr (std::is_same_v<T, DataTree::Array>)
         {
@@ -311,13 +630,27 @@ public:
     }
 
     // Get underlying value
+
+    /**
+     * Get a reference to the underlying value variant.
+     * \return A reference to the underlying Value variant.
+     */
     Value& get_value() { return value_; }
+
+    /**
+     * Get a const reference to the underlying value variant.
+     * \return A const reference to the underlying Value variant.
+     */
     const Value& get_value() const { return value_; }
 
 private:
     Value value_;
 };
 
+/// @}
+
 } // namespace gul17
 
 #endif // GUL17_DATA_TREE_H_
+
+// vi:ts=4:sw=4:sts=4:et

--- a/include/gul17/DataTree.h
+++ b/include/gul17/DataTree.h
@@ -53,8 +53,8 @@ namespace gul17 {
  * tree["foo"] = "bar";          // String
  * tree["answer"] = 42;          // Number
  * tree["is_valid"] = true;     // Boolean
- * tree["items"] = DataTree::array{1, 2, 3}; // Array
- * tree["config"] = DataTree::object{ {"key1", "value1"}, {"key2", 42} }; // Object
+ * tree["items"] = DataTree::Array{1, 2, 3}; // Array
+ * tree["config"] = DataTree::Object{ {"key1", "value1"}, {"key2", 42} }; // Object
  *
  * tree["items"].push_back(4);  // Add an element to the array
  * tree["config"]["key3"] = 3.14; // Add a key-value pair to the object

--- a/include/gul17/DataTree.h
+++ b/include/gul17/DataTree.h
@@ -23,9 +23,9 @@
 #ifndef GUL17_DATA_TREE_H_
 #define GUL17_DATA_TREE_H_
 
+#include <map>
 #include <stdexcept>
 #include <string>
-#include <unordered_map>
 #include <variant>
 #include <vector>
 
@@ -68,7 +68,7 @@ public:
     // Type definitions
 
     /// Type of an object (key-value pairs)
-    using Object = std::unordered_map<std::string, DataTree>;
+    using Object = std::map<std::string, DataTree>;
     /// Type of an array (list of values)
     using Array = std::vector<DataTree>;
     /// Underlying variant type to hold different data types

--- a/include/gul17/DataTree.h
+++ b/include/gul17/DataTree.h
@@ -351,8 +351,8 @@ public:
     }
 
     // Iterator return types, only works for arrays
-    using iterator = DataTree*;
-    using const_iterator = const DataTree*;
+    using iterator = std::vector<DataTree>::iterator;
+    using const_iterator = const std::vector<DataTree>::iterator;
 
     // Iterators
 
@@ -366,7 +366,7 @@ public:
         if (!is_array())
             throw std::runtime_error("DataTree is not an array");
         auto& arr = std::get<Array>(value_);
-        return arr.data();
+        return arr.begin();
     }
 
     /**
@@ -379,7 +379,7 @@ public:
         if (!is_array())
             throw std::runtime_error("DataTree is not an array");
         auto& arr = std::get<Array>(value_);
-        return arr.data() + arr.size();
+        return arr.end();
     }
 
     /**
@@ -585,6 +585,8 @@ public:
      * - int to double
      * - boolean to int
      * - int/double/boolean/null to string
+     *
+     * It is not possible to convert complex types (array/object) to primitive types.
      */
     template<typename T>
     T as() const
@@ -615,7 +617,6 @@ public:
             if (is_double()) return std::to_string(std::get<double>(value_));
             if (is_boolean()) return std::get<bool>(value_) ? "true" : "false";
             if (is_null()) return "null";
-            // TODO: Add conversion logic for other types to string if needed
         }
         else if constexpr (std::is_same_v<T, DataTree::Array>)
         {

--- a/include/gul17/DataTree.h
+++ b/include/gul17/DataTree.h
@@ -1,0 +1,323 @@
+/**
+ * \file   DataTree.h
+ * \author Jan Behrens
+ * \date   Created on 19 November 2025
+ * \brief  Declaration of the DataTree class.
+ *
+ * \copyright Copyright 2018-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#ifndef GUL17_DATA_TREE_H_
+#define GUL17_DATA_TREE_H_
+
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <variant>
+#include <vector>
+
+namespace gul17 {
+
+class DataTree
+{
+public:
+    using Object = std::unordered_map<std::string, DataTree>;
+    using Array = std::vector<DataTree>;
+    using Value = std::variant<
+        std::nullptr_t,    // null
+        bool,              // boolean
+        int,               // integer
+        double,            // float
+        std::string,       // string
+        Array,             // array
+        Object             // object
+    >;
+
+    // Constructors
+    DataTree() : value_(Object()) {}  // default to an empty object
+    DataTree(std::nullptr_t) : value_(nullptr) {}
+    DataTree(bool b) : value_(b) {}
+    DataTree(int i) : value_(i) {}
+    DataTree(double d) : value_(d) {}
+    DataTree(const std::string& s) : value_(s) {}
+    DataTree(const char* s) : value_(std::string(s)) {}
+    DataTree(const Array& a) : value_(a) {}
+    DataTree(const Object& o) : value_(o) {}
+
+    // Factory methods
+    static DataTree make_array() { return DataTree(Array{}); }
+    static DataTree make_object() { return DataTree(Object{}); }
+
+    // Move constructors
+    DataTree(Array&& a) : value_(std::move(a)) {}
+    DataTree(Object&& o) : value_(std::move(o)) {}
+    DataTree(std::string&& s) : value_(std::move(s)) {}
+
+    // Copy constructor
+    DataTree(const DataTree& other) = default;
+
+    // Move constructor
+    DataTree(DataTree&& other) = default;
+
+    // Assignment operators
+    DataTree& operator=(const DataTree& other) = default;
+    DataTree& operator=(DataTree&& other) = default;
+
+    // Type checking
+    bool is_null() const    { return std::holds_alternative<std::nullptr_t>(value_); }
+    bool is_boolean() const { return std::holds_alternative<bool>(value_); }
+    bool is_int() const     { return std::holds_alternative<int>(value_); }
+    bool is_double() const  { return std::holds_alternative<double>(value_); }
+    bool is_number() const  { return is_int() || is_double(); }
+    bool is_string() const  { return std::holds_alternative<std::string>(value_); }
+    bool is_array() const   { return std::holds_alternative<Array>(value_); }
+    bool is_object() const  { return std::holds_alternative<Object>(value_); }
+
+    bool is_empty() const
+    {
+        if (is_null()) return true;
+        if (is_string()) return std::get<std::string>(value_).empty();
+        if (is_array()) return std::get<Array>(value_).empty();
+        if (is_object()) return std::get<Object>(value_).empty();
+        return false;
+    }
+
+    bool has_key(const std::string& key) const
+    {
+        if (!is_object())
+            throw std::runtime_error("DataTree is not an object");
+        const auto& obj = std::get<Object>(value_);
+        return obj.find(key) != obj.end();
+    }
+
+    size_t size() const
+    {
+        if (is_array())
+            return std::get<Array>(value_).size();
+        else if (is_object())
+            return std::get<Object>(value_).size();
+        else
+            throw std::runtime_error("DataTree is neither array nor object");
+    }
+
+    void push_back(const DataTree& val)
+    {
+        if (!is_array())
+            throw std::runtime_error("DataTree is not an array");
+        std::get<Array>(value_).push_back(val);
+    }
+
+    void emplace_back(DataTree&& val)
+    {
+        if (!is_array())
+            throw std::runtime_error("DataTree is not an array");
+        std::get<Array>(value_).emplace_back(std::move(val));
+    }
+
+    void insert(const std::string& key, const DataTree& val)
+    {
+        if (!is_object())
+            throw std::runtime_error("DataTree is not an object");
+        std::get<Object>(value_)[key] = val;
+    }
+
+    void insert(size_t index, const DataTree& val)
+    {
+        if (!is_array())
+            throw std::runtime_error("DataTree is not an array");
+        auto& arr = std::get<Array>(value_);
+        if (index > arr.size())
+            throw std::out_of_range("Index out of range: " + std::to_string(index));
+        arr.insert(arr.begin() + index, val);
+    }
+
+    void clear()
+    {
+        if (is_array())
+            std::get<Array>(value_).clear();
+        else if (is_object())
+            std::get<Object>(value_).clear();
+        else
+            throw std::runtime_error("DataTree is neither array nor object");
+    }
+
+    // Iterator return types, only works for arrays
+    using iterator = DataTree*;
+    using const_iterator = const DataTree*;
+
+    // Iterators
+    iterator begin()
+    {
+        if (!is_array())
+            throw std::runtime_error("DataTree is not an array");
+        auto& arr = std::get<Array>(value_);
+        return arr.data();
+    }
+
+    iterator end()
+    {
+        if (!is_array())
+            throw std::runtime_error("DataTree is not an array");
+        auto& arr = std::get<Array>(value_);
+        return arr.data() + arr.size();
+    }
+
+    const_iterator cbegin() const { return const_cast<DataTree*>(this)->begin(); }
+    const_iterator cend() const { return const_cast<DataTree*>(this)->end(); }
+
+    const_iterator begin() const { return cbegin(); }
+    const_iterator end() const { return cend(); }
+
+    // Accessors with bounds checking
+    DataTree& at(const std::string& key)
+    {
+        if (!is_object())
+            throw std::runtime_error("DataTree is not an object");
+        const auto& obj = std::get<Object>(value_);
+        auto it = obj.find(key);
+        if (it == obj.end())
+            throw std::out_of_range("Key not found in object: " + key);
+        return const_cast<DataTree&>(it->second);
+    }
+    const DataTree& at(const std::string& key) const
+    {
+        return const_cast<DataTree*>(this)->at(key);
+    }
+    DataTree& at(size_t index)
+    {
+        if (!is_array())
+            throw std::runtime_error("DataTree is not an array");
+        const auto& arr = std::get<Array>(value_);
+        if (index >= arr.size())
+            throw std::out_of_range("Index out of range: " + std::to_string(index));
+        return const_cast<DataTree&>(arr[index]);
+    }
+    const DataTree& at(size_t index) const
+    {
+        return const_cast<DataTree*>(this)->at(index);
+    }
+
+    // Operator[] without bounds checking
+    DataTree& operator[](const std::string& key)
+    {
+        if (!is_object())
+            throw std::runtime_error("DataTree is not an object");
+        return std::get<Object>(value_)[key];
+    }
+    const DataTree& operator[](const std::string& key) const
+    {
+        return (*const_cast<DataTree*>(this))[key];
+    }
+    DataTree& operator[](size_t index)
+    {
+        if (!is_array())
+            throw std::runtime_error("DataTree is not an array");
+        return std::get<Array>(value_)[index];
+    }
+    const DataTree& operator[](size_t index) const
+    {
+        return (*const_cast<DataTree*>(this))[index];
+    }
+
+    template<typename T>
+    bool is() const
+    {
+        if constexpr (std::is_same_v<T, std::nullptr_t>)
+        {
+            return is_null();
+        }
+        else if constexpr (std::is_same_v<T, bool>)
+        {
+            return is_boolean();
+        }
+        else if constexpr (std::is_same_v<T, int>)
+        {
+            return is_int();
+        }
+        else if constexpr (std::is_same_v<T, double>)
+        {
+            return is_double();
+        }
+        else if constexpr (std::is_same_v<T, std::string>)
+        {
+            return is_string();
+        }
+        else if constexpr (std::is_same_v<T, DataTree::Array>)
+        {
+            return is_array();
+        }
+        else if constexpr (std::is_same_v<T, DataTree::Object>)
+        {
+            return is_object();
+        }
+        return false;
+    }
+
+    // Conversion
+    template<typename T>
+    T as() const
+    {
+        if constexpr (std::is_same_v<T, std::nullptr_t>)
+        {
+            if (is_null()) return std::get<std::nullptr_t>(value_);
+        }
+        else if constexpr (std::is_same_v<T, bool>)
+        {
+            if (is_boolean()) return std::get<bool>(value_);
+        }
+        else if constexpr (std::is_same_v<T, int>)
+        {
+            if (is_int()) return std::get<int>(value_);
+            if (is_double()) return static_cast<int>(std::get<double>(value_));
+            if (is_boolean()) return static_cast<int>(std::get<bool>(value_));
+        }
+        else if constexpr (std::is_same_v<T, double>)
+        {
+            if (is_double()) return std::get<double>(value_);
+            if (is_int()) return static_cast<double>(std::get<int>(value_));
+        }
+        else if constexpr (std::is_same_v<T, std::string>)
+        {
+            if (is_string()) return std::get<std::string>(value_);
+            if (is_int()) return std::to_string(std::get<int>(value_));
+            if (is_double()) return std::to_string(std::get<double>(value_));
+            if (is_boolean()) return std::get<bool>(value_) ? "true" : "false";
+            if (is_null()) return "null";
+            // Add conversion logic for other types to string if needed
+        }
+        else if constexpr (std::is_same_v<T, DataTree::Array>)
+        {
+            if (is_array()) return std::get<Array>(value_);
+        }
+        else if constexpr (std::is_same_v<T, DataTree::Object>)
+        {
+            if (is_object()) return std::get<Object>(value_);
+        }
+
+        throw std::bad_variant_access();
+    }
+
+    // Get underlying value
+    Value& get_value() { return value_; }
+    const Value& get_value() const { return value_; }
+
+private:
+    Value value_;
+};
+
+} // namespace gul17
+
+#endif // GUL17_DATA_TREE_H_

--- a/include/gul17/data_processors.h
+++ b/include/gul17/data_processors.h
@@ -1,0 +1,55 @@
+/**
+ * \file   YamlDataProcessor.h
+ * \author Jan Behrens
+ * \date   Created on 20 November 2025
+ * \brief  Declaration of the YamlDataProcessor class.
+ *
+ * \copyright Copyright 2018-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.or
+ */
+
+#ifndef GUL17_DATA_PROCESSORS_H_
+#define GUL17_DATA_PROCESSORS_H_
+
+#include "DataTree.h"
+
+#include "gul17/internal.h"
+#include "gul17/traits.h"
+
+#include <string>
+
+namespace gul17 {
+
+GUL_EXPORT
+DataTree from_json_string(const std::string& data);
+
+GUL_EXPORT
+std::string to_json_string(const DataTree& value, size_t indent = 0);
+
+GUL_EXPORT
+DataTree from_xml_string(const std::string& data);
+
+GUL_EXPORT
+std::string to_xml_string(const DataTree& value, size_t indent = 0, const std::string& root_tag_name = "root");
+
+GUL_EXPORT
+DataTree from_yaml_string(const std::string& data);
+
+GUL_EXPORT
+std::string to_yaml_string(const DataTree& value, size_t indent = 0);
+
+} // namespace gul17
+
+#endif // GUL17_DATA_PROCESSORS_H_

--- a/include/gul17/data_processors.h
+++ b/include/gul17/data_processors.h
@@ -17,7 +17,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
 #ifndef GUL17_DATA_PROCESSORS_H_

--- a/include/gul17/data_processors.h
+++ b/include/gul17/data_processors.h
@@ -1,8 +1,8 @@
 /**
- * \file   YamlDataProcessor.h
+ * \file   data_processors.h
  * \author Jan Behrens
  * \date   Created on 20 November 2025
- * \brief  Declaration of the YamlDataProcessor class.
+ * \brief  Declaration of the data processor utility functions.
  *
  * \copyright Copyright 2018-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
@@ -26,30 +26,142 @@
 #include "DataTree.h"
 
 #include "gul17/internal.h"
-#include "gul17/traits.h"
 
 #include <string>
 
 namespace gul17 {
 
-GUL_EXPORT
-DataTree from_json_string(const std::string& data);
+/**
+ * \addtogroup data_processors_h gul17/data_processors.h
+ * \brief Various data processor utility functions.
+ * @{
+ */
 
+/**
+ * Parse a JSON string and return the corresponding DataTree representation.
+ *
+ * The function parses the input JSON string and constructs a DataTree object
+ * representing the hierarchical structure and data contained in the JSON.
+ * Throws a std::runtime_error if the input string is not valid JSON.
+ *
+ * \code
+ * auto a = from_json_string(R"({"foo": "bar"})");  // a == DataTree{"foo": "bar"}
+ * \endcode
+ *
+ * \param data      The JSON string to be parsed.
+ *
+ * \see to_json_string()
+ *
+ * \since GUL version x.y.z
+ */
+GUL_EXPORT
+DataTree from_json_string(const std::string_view& data);
+
+/**
+ * Serialize a DataTree object to a JSON string.
+ *
+ * The function serializes the given DataTree object into a JSON-formatted string.
+ * The optional \c indent parameter specifies the number of spaces to use for
+ * indentation in the output string (default is 0, meaning no pretty-printing).
+ *
+ * \code
+ * auto a = to_json_string(DataTree{"foo": "bar"});  // a == "{\"foo\": \"bar\"}"
+ * \endcode
+ *
+ * \param value     The DataTree object to be serialized.
+ *
+ * \see from_json_string()
+ *
+ * \since GUL version x.y.z
+ */
 GUL_EXPORT
 std::string to_json_string(const DataTree& value, size_t indent = 0);
 
+/**
+ * Parse an XML string and return the corresponding DataTree representation.
+ *
+ * The function parses the input XML string and constructs a DataTree object
+ * representing the hierarchical structure and data contained in the XML.
+ * Throws a std::runtime_error if the input string is not valid XML.
+ *
+ * \code
+ * auto a = from_xml_string(R"(<root><foo>bar</foo></root>)");  // a == DataTree{"foo": "bar"}
+ * \endcode
+ *
+ * \param data      The XML string to be parsed.
+ *
+ * \see to_xml_string()
+ *
+ * \since GUL version x.y.z
+ */
 GUL_EXPORT
-DataTree from_xml_string(const std::string& data);
+DataTree from_xml_string(const std::string_view& data);
 
+/**
+ * Serialize a DataTree object to an XML string.
+ *
+ * The function serializes the given DataTree object into a XML-formatted string.
+ * The optional \c indent parameter specifies the number of spaces to use for
+ * indentation in the output string (default is 0, meaning no pretty-printing).
+ *
+ * \code
+ * auto a = to_xml_string(DataTree{"foo": "bar"});  // a == "<root><foo>bar</foo></root>"
+ * \endcode
+ *
+ * \param value     The DataTree object to be serialized.
+ *
+ * \see from_xml_string()
+ *
+ * \since GUL version x.y.z
+ */
 GUL_EXPORT
-std::string to_xml_string(const DataTree& value, size_t indent = 0, const std::string& root_tag_name = "root");
+std::string to_xml_string(const DataTree& value, size_t indent = 0,
+                          const std::string& root_tag_name = "root");
 
+/**
+ * Parse an YAML string and return the corresponding DataTree representation.
+ *
+ * The function parses the input YAML string and constructs a DataTree object
+ * representing the hierarchical structure and data contained in the YAML.
+ * Throws a std::runtime_error if the input string is not valid YAML.
+ *
+ * \code
+ * auto a = from_yaml_string(R"(foo: bar)");  // a == DataTree{"foo": "bar"}
+ * \endcode
+ *
+ * \param data      The YAML string to be parsed.
+ *
+ * \see to_yaml_string()
+ *
+ * \since GUL version x.y.z
+ */
 GUL_EXPORT
-DataTree from_yaml_string(const std::string& data);
+DataTree from_yaml_string(const std::string_view& data);
 
+/**
+ * Serialize a DataTree object to a YAML string.
+ *
+ * The function serializes the given DataTree object into a YAML-formatted string.
+ * The optional \c indent parameter specifies the number of spaces to use for
+ * indentation in the output string (default is 2).
+ *
+ * \code
+ * auto a = to_yaml_string(DataTree{"foo": "bar"});  // a == "foo: bar\n"
+ * \endcode
+ *
+ * \param value     The DataTree object to be serialized.
+ *
+ * \see from_yaml_string()
+ *
+ * \since GUL version x.y.z
+ */
 GUL_EXPORT
-std::string to_yaml_string(const DataTree& value, size_t indent = 0);
+std::string to_yaml_string(const DataTree& value, size_t indent = 2);
+
+/// @}
 
 } // namespace gul17
 
 #endif // GUL17_DATA_PROCESSORS_H_
+
+// vi:ts=4:sw=4:sts=4:et

--- a/include/gul17/data_processors.h
+++ b/include/gul17/data_processors.h
@@ -17,7 +17,7 @@
  * GNU Lesser General Public License for more details.
  *
  * You should have received a copy of the GNU Lesser General Public License
- * along with this program.  If not, see <https://www.gnu.or
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>
  */
 
 #ifndef GUL17_DATA_PROCESSORS_H_

--- a/include/gul17/data_processors.h
+++ b/include/gul17/data_processors.h
@@ -100,7 +100,7 @@ DataTree from_xml_string(const std::string_view& data);
 /**
  * Serialize a DataTree object to an XML string.
  *
- * The function serializes the given DataTree object into a XML-formatted string.
+ * The function serializes the given DataTree object into an XML-formatted string.
  * The optional \c indent parameter specifies the number of spaces to use for
  * indentation in the output string (default is 0, meaning no pretty-printing).
  *
@@ -119,7 +119,7 @@ std::string to_xml_string(const DataTree& value, size_t indent = 0,
                           const std::string& root_tag_name = "root");
 
 /**
- * Parse an YAML string and return the corresponding DataTree representation.
+ * Parse a YAML string and return the corresponding DataTree representation.
  *
  * The function parses the input YAML string and constructs a DataTree object
  * representing the hierarchical structure and data contained in the YAML.

--- a/include/gul17/gul.h
+++ b/include/gul17/gul.h
@@ -41,6 +41,7 @@
 #include "gul17/cat.h"
 // #include "gul17/catch.h" not included because it is only useful for unit tests
 // #include "gul17/date.h" not included by default to reduce compile times
+#include "gul17/data_processors.h"
 #include "gul17/escape.h"
 #include "gul17/expected.h"
 #include "gul17/finalizer.h"

--- a/include/gul17/meson.build
+++ b/include/gul17/meson.build
@@ -4,6 +4,8 @@ standalone_headers = [
     'case_ascii.h',
     'cat.h',
     'date.h',
+    'data_processors.h',
+    'DataTree.h',
     'escape.h',
     'expected.h',
     'finalizer.h',

--- a/src/data_processors/json_processor.cc
+++ b/src/data_processors/json_processor.cc
@@ -21,6 +21,7 @@
  */
 
 #include "gul17/data_processors.h"
+#include "gul17/cat.h"
 
 #include <algorithm>
 #include <sstream>
@@ -58,7 +59,7 @@ private:
                 return parse_number();
 
             default:
-                throw std::runtime_error("Unexpected character");
+                throw std::runtime_error(gul17::cat("Unexpected character: ", c, " at position ", pos_));
         }
     }
 
@@ -203,7 +204,7 @@ private:
                         throw std::runtime_error("Unicode escape sequences not supported");
 
                     default:
-                        throw std::runtime_error("Invalid escape sequence");
+                        throw std::runtime_error(gul17::cat("Invalid escape sequence: ", esc, " at position ", pos_));
                 }
                 advance();
             }
@@ -231,7 +232,7 @@ private:
         }
         else
         {
-            throw std::runtime_error("Invalid boolean value");
+            throw std::runtime_error(gul17::cat("Invalid boolean value at position ", pos_));
         }
     }
 
@@ -244,7 +245,7 @@ private:
         }
         else
         {
-            throw std::runtime_error("Invalid null value");
+            throw std::runtime_error(gul17::cat("Invalid null value at position ", pos_));
         }
     }
 
@@ -317,7 +318,7 @@ private:
             }
             else
             {
-                throw std::runtime_error("Invalid comment syntax");
+                throw std::runtime_error(gul17::cat("Invalid comment syntax at position ", pos_));
             }
         }
     }
@@ -346,8 +347,7 @@ private:
     {
         if (current_char() != expected)
         {
-            //fprintf(stderr, "Expected '%c' but found '%c' at position %d\n", expected, current_char(), pos_);
-            throw std::runtime_error("Expected character not found");
+            throw std::runtime_error(gul17::cat("Expected character not found: ", expected, " at position ", pos_));
         }
         advance();
     }

--- a/src/data_processors/json_processor.cc
+++ b/src/data_processors/json_processor.cc
@@ -439,23 +439,15 @@ private:
         output_ << "{";
         if (!obj.empty())
         {
-            // Sort keys for consistent output
-            std::vector<DataTree::Object::key_type> keys;
-            std::transform(obj.begin(), obj.end(), std::back_inserter(keys),
-                           [](const auto& pair) { return pair.first; });
-            std::sort(keys.begin(), keys.end());
-
             output_ << newline;
-            for (size_t i = 0; i < keys.size(); ++i)
+            size_t i = 0;
+            for (const auto & [key, val] : obj)
             {
-                const auto& key = keys[i];
-                const auto& val = obj.at(key);
-
                 output_ << std::string(current_indent + indent, ' ');
                 output_ << "\"" << escape_string(key) << "\": ";
                 serialize_value(val, indent, current_indent + indent);
 
-                if (i < keys.size() - 1)
+                if (i++ < obj.size() - 1)
                     output_ << ",";
                 output_ << newline;
             }

--- a/src/data_processors/json_processor.cc
+++ b/src/data_processors/json_processor.cc
@@ -164,7 +164,7 @@ private:
                         {
                             auto num = data_.substr(pos_ + 1, 4);
                             try {
-                                unsigned ch = std::stoi(std::string(num), nullptr, 16);
+                                auto ch = std::stoi(std::string(num), nullptr, 16);
                                 if (ch < 0x80)
                                 {
                                     result += static_cast<char>(ch);

--- a/src/data_processors/json_processor.cc
+++ b/src/data_processors/json_processor.cc
@@ -1,0 +1,473 @@
+#include "gul17/data_processors.h"
+
+#include <algorithm>
+#include <sstream>
+
+using gul17::DataTree;
+
+struct JsonDataProcessorParser
+{
+    JsonDataProcessorParser(const std::string_view& json_str) : data_(json_str)
+    {}
+
+    DataTree parse() { return parse_value(); }
+
+private:
+    DataTree parse_value()
+    {
+        skip_comment();
+        skip_whitespace();
+        char c = current_char();
+
+        switch (c) {
+            case '{': return parse_object();
+            case '[': return parse_array();
+            case '"': return parse_string();
+            case 't': case 'f': return parse_boolean();
+            case 'n': return parse_null();
+            case '-': case '0': case '1': case '2': case '3': case '4':
+            case '5': case '6': case '7': case '8': case '9':
+                return parse_number();
+            default:
+                throw std::runtime_error("Unexpected character");
+        }
+    }
+
+    DataTree parse_object()
+    {
+        expect('{');
+        DataTree::Object obj;
+
+        skip_comment();
+        skip_whitespace();
+        if (current_char() == '}')
+        {
+            advance();
+            return DataTree(obj);
+        }
+
+        while (true)
+        {
+            skip_whitespace();
+            std::string key = parse_string().as<std::string>();
+
+            skip_whitespace();
+            expect(':');
+
+            DataTree value = parse_value();
+            obj.emplace(std::move(key), std::move(value));
+
+            skip_whitespace();
+            if (current_char() == '}')
+            {
+                advance();
+                break;
+            }
+            expect(',');
+        }
+
+        return DataTree(obj);
+    }
+
+    DataTree parse_array()
+    {
+        expect('[');
+        DataTree::Array arr;
+
+        skip_comment();
+        skip_whitespace();
+        if (current_char() == ']')
+        {
+            advance();
+            return DataTree(arr);
+        }
+
+        while (true)
+        {
+            arr.push_back(parse_value());
+
+            skip_whitespace();
+            if (current_char() == ']')
+            {
+                advance();
+                break;
+            }
+            expect(',');
+        }
+
+        return DataTree(arr);
+    }
+
+    DataTree parse_string()
+    {
+        expect('"');
+        std::string result;
+
+        while (true)
+        {
+            char c = current_char();
+            if (c == '"')
+            {
+                advance();
+                break;
+            }
+            else if (c == '\\')
+            {
+                // TODO - Implement full JSON string unescaping
+
+                advance();
+                char esc = current_char();
+                switch (esc)
+                {
+                    case '"': result += '"'; break;
+                    case '\\': result += '\\'; break;
+                    case '/': result += '/'; break;
+                    case 'a': result += '\a'; break;
+                    case 'b': result += '\b'; break;
+                    case 'f': result += '\f'; break;
+                    case 'n': result += '\n'; break;
+                    case 'r': result += '\r'; break;
+                    case 't': result += '\t'; break;
+                    case 'v': result += '\v'; break;
+
+                    case 'u':
+                        // Unicode escape sequence (e.g., \uXXXX)
+                        if (pos_ + 5 < data_.length())
+                        {
+                            auto num = data_.substr(pos_ + 1, 4);
+                            try {
+                                unsigned ch = std::stoi(std::string(num), nullptr);
+                                if (ch < 0x80)
+                                {
+                                    result += static_cast<char>(ch);
+                                }
+                                else if (ch < 0x800)
+                                {
+                                    result += static_cast<char>(0xC0 | (ch >> 6));
+                                    result += static_cast<char>(0x80 | (ch & 0x3F));
+                                }
+                                else if (ch < 0x10000)
+                                {
+                                    result += static_cast<char>(0xE0 | (ch >> 12));
+                                    result += static_cast<char>(0x80 | ((ch >> 6) & 0x3F));
+                                    result += static_cast<char>(0x80 | (ch & 0x3F));
+                                }
+                                else
+                                {
+                                    result += static_cast<char>(0xF0 | (ch >> 18));
+                                    result += static_cast<char>(0x80 | ((ch >> 12) & 0x3F));
+                                    result += static_cast<char>(0x80 | ((ch >> 6) & 0x3F));
+                                    result += static_cast<char>(0x80 | (ch & 0x3F));
+                                }
+                                pos_ += 4;
+                            }
+                            catch (...) {
+                                result += data_[pos_ + 1]; // Invalid number, treat as literal
+                                pos_ += 1;
+                            }
+                        }
+                        break;
+
+                    case 'U':
+                        // Unicode escape sequence (e.g., \UXXXXXXXX)
+                        // FIXME - Unicode escape sequences not implemented yet
+                        throw std::runtime_error("Unicode escape sequences not supported");
+
+                    default:
+                        throw std::runtime_error("Invalid escape sequence");
+                }
+                advance();
+            }
+            else
+            {
+                result += c;
+                advance();
+            }
+        }
+
+        return DataTree(result);
+    }
+
+    DataTree parse_boolean()
+    {
+        if (data_.compare(pos_, 4, "true") == 0)
+        {
+            pos_ += 4;
+            return DataTree(true);
+        }
+        else if (data_.compare(pos_, 5, "false") == 0)
+        {
+            pos_ += 5;
+            return DataTree(false);
+        }
+        else
+        {
+            throw std::runtime_error("Invalid boolean value");
+        }
+    }
+
+    DataTree parse_null()
+    {
+        if (data_.compare(pos_, 4, "null") == 0)
+        {
+            pos_ += 4;
+            return DataTree(nullptr);
+        }
+        else
+        {
+            throw std::runtime_error("Invalid null value");
+        }
+    }
+
+    DataTree parse_number()
+    {
+        auto start_pos = pos_;
+        if (current_char() == '-')
+        {
+            advance();
+        }
+
+        while (std::isdigit(current_char()))
+        {
+            advance();
+        }
+
+        if (current_char() == '.')
+        {
+            advance();
+            while (std::isdigit(current_char()))
+            {
+                advance();
+            }
+            double value = std::stod(std::string(data_.substr(start_pos, pos_ - start_pos)));
+            return DataTree(value);
+        }
+        else
+        {
+            int value = std::stoi(std::string(data_.substr(start_pos, pos_ - start_pos)));
+            return DataTree(value);
+        }
+    }
+
+    void skip_whitespace()
+    {
+        while (pos_ < data_.size() && std::isspace(data_[pos_]))
+        {
+            advance();
+        }
+    }
+
+    void skip_comment()
+    {
+        skip_whitespace();
+
+        if (current_char() == '/')
+        {
+            // Skip comments
+            if (next_char() == '/')
+            {
+                // Single-line comment
+                while (has_remaining_chars() && current_char() != '\n')
+                {
+                    advance();
+                }
+            }
+            else if (next_char() == '*')
+            {
+                // Multi-line comment
+                advance(2);
+                while (has_remaining_chars())
+                {
+                    if (current_char() == '*' && next_char() == '/')
+                    {
+                        advance(2);
+                        break;
+                    }
+                    advance();
+                }
+            }
+            else
+            {
+                throw std::runtime_error("Invalid comment syntax");
+            }
+        }
+    }
+
+    char current_char() const
+    {
+        return pos_ < data_.size() ? data_[pos_] : '\0';
+    }
+
+    char next_char() const
+    {
+        return pos_ + 1 < data_.size() ? data_[pos_+1] : '\0';
+    }
+
+    bool has_remaining_chars() const
+    {
+        return pos_ < data_.size();
+    }
+
+    void advance(size_t n = 1)
+    {
+        pos_ += n;
+    }
+
+    void expect(char expected)
+    {
+        if (current_char() != expected)
+        {
+            //fprintf(stderr, "Expected '%c' but found '%c' at position %d\n", expected, current_char(), pos_);
+            throw std::runtime_error("Expected character not found");
+        }
+        advance();
+    }
+
+private:
+    std::string_view data_;
+    size_t pos_{0};
+};
+
+struct JsonDataProcessorSerializer
+{
+    static std::string serialize(
+        const DataTree& value, size_t indent)
+    {
+        std::ostringstream oss;
+        serialize_value(oss, value, indent);
+        return oss.str();
+    }
+
+private:
+    static void serialize_value(
+        std::ostringstream& oss, const DataTree& value, size_t indent, size_t current_indent = 0)
+    {
+        if (value.is_null())
+        {
+            oss << "null";
+        }
+        else if (value.is_boolean())
+        {
+            oss << (value.as<bool>() ? "true" : "false");
+        }
+        else if (value.is_int())
+        {
+            oss << std::to_string(value.as<int>());
+        }
+        else if (value.is_double())
+        {
+            oss << std::to_string(value.as<double>());
+        }
+        else if (value.is_string())
+        {
+            oss << "\"" << escape_string(value.as<std::string>()) << "\"";
+        }
+        else if (value.is_array())
+        {
+            serialize_array(oss, value.as<DataTree::Array>(), indent, current_indent);
+        }
+        else if (value.is_object())
+        {
+            serialize_object(oss, value.as<DataTree::Object>(), indent, current_indent);
+        }
+    }
+
+    static void serialize_array(
+        std::ostringstream& oss, const DataTree::Array& arr, size_t indent, size_t current_indent)
+    {
+        oss << "[";
+        if (!arr.empty())
+        {
+            oss << "\n";
+            for (size_t i = 0; i < arr.size(); ++i)
+            {
+                oss << std::string(current_indent + indent, ' ');
+                serialize_value(oss, arr[i], indent, current_indent + indent);
+
+                if (i < arr.size() - 1)
+                    oss << ",";
+                oss << "\n";
+            }
+            oss << std::string(current_indent, ' ');
+        }
+        oss << "]";
+    }
+
+    static void serialize_object(
+        std::ostringstream& oss, const DataTree::Object& obj, size_t indent, size_t current_indent)
+    {
+        oss << "{";
+        if (!obj.empty())
+        {
+            // Sort keys for consistent output
+            std::vector<DataTree::Object::key_type> keys;
+            std::transform(obj.begin(), obj.end(), std::back_inserter(keys),
+                           [](const auto& pair) { return pair.first; });
+            std::sort(keys.begin(), keys.end());
+
+            oss << "\n";
+            for (size_t i = 0; i < keys.size(); ++i)
+            {
+                const auto& key = keys[i];
+                const auto& val = obj.at(key);
+
+                oss << std::string(current_indent + indent, ' ');
+                oss << "\"" << escape_string(key) << "\": ";
+                serialize_value(oss, val, indent, current_indent + indent);
+
+                if (i < keys.size() - 1)
+                    oss << ",";
+                oss << "\n";
+            }
+            oss << std::string(current_indent, ' ');
+        }
+        oss << "}";
+    }
+
+    static std::string escape_string(const std::string& str)
+    {
+        std::string result;
+        result.reserve(str.size() + 2); // Reserve space for efficiency
+        for (char c : str)
+        {
+            switch (c)
+            {
+                case '"': result += "\\\""; break;
+                case '\\': result += "\\\\"; break;
+                case '\a': result += "\\a"; break;
+                case '\b': result += "\\b"; break;
+                case '\f': result += "\\f"; break;
+                case '\n': result += "\\n"; break;
+                case '\r': result += "\\r"; break;
+                case '\t': result += "\\t"; break;
+                case '\v': result += "\\v"; break;
+
+                default:
+                    // escape control characters
+                    if (static_cast<unsigned char>(c) < 0x20)
+                    {
+                        char buf[7];
+                        snprintf(buf, sizeof(buf), "\\u%04x", static_cast<unsigned char>(c));
+                        result += buf;
+                    }
+                    else
+                    {
+                        result += c;
+                    }
+            }
+        }
+
+        return result;
+    }
+};
+
+DataTree from_json_string(const std::string& data)
+{
+    JsonDataProcessorParser parser(data);
+    return parser.parse();
+}
+
+std::string to_json_string(const DataTree& value, size_t indent)
+{
+    return JsonDataProcessorSerializer::serialize(value, indent);
+}

--- a/src/data_processors/json_processor.cc
+++ b/src/data_processors/json_processor.cc
@@ -1,4 +1,26 @@
-#include "gul17/data_processors.h"
+/**
+ * \file   json_processor.cc
+ * \author Jan Behrens
+ * \date   Created on 20 November 2025
+ * \brief  Implementation of the JSON data processor functions.
+ *
+ * \copyright Copyright 2018-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+ #include "gul17/data_processors.h"
 
 #include <algorithm>
 #include <sstream>
@@ -7,10 +29,14 @@ using gul17::DataTree;
 
 struct JsonDataProcessorParser
 {
-    JsonDataProcessorParser(const std::string_view& json_str) : data_(json_str)
+    JsonDataProcessorParser(const std::string_view& json_str)
+        : data_(json_str)
     {}
 
-    DataTree parse() { return parse_value(); }
+    DataTree parse()
+    {
+        return parse_value();
+    }
 
 private:
     DataTree parse_value()
@@ -19,15 +45,18 @@ private:
         skip_whitespace();
         char c = current_char();
 
-        switch (c) {
+        switch (c)
+        {
             case '{': return parse_object();
             case '[': return parse_array();
             case '"': return parse_string();
             case 't': case 'f': return parse_boolean();
             case 'n': return parse_null();
-            case '-': case '0': case '1': case '2': case '3': case '4':
+            case '-':
+            case '0': case '1': case '2': case '3': case '4':
             case '5': case '6': case '7': case '8': case '9':
                 return parse_number();
+
             default:
                 throw std::runtime_error("Unexpected character");
         }
@@ -461,7 +490,7 @@ private:
     }
 };
 
-DataTree from_json_string(const std::string& data)
+DataTree from_json_string(const std::string_view& data)
 {
     JsonDataProcessorParser parser(data);
     return parser.parse();
@@ -471,3 +500,5 @@ std::string to_json_string(const DataTree& value, size_t indent)
 {
     return JsonDataProcessorSerializer::serialize(value, indent);
 }
+
+// vi:ts=4:sw=4:sts=4:et

--- a/src/data_processors/json_processor.cc
+++ b/src/data_processors/json_processor.cc
@@ -152,13 +152,11 @@ private:
                     case '"': result += '"'; break;
                     case '\\': result += '\\'; break;
                     case '/': result += '/'; break;
-                    case 'a': result += '\a'; break;
                     case 'b': result += '\b'; break;
                     case 'f': result += '\f'; break;
                     case 'n': result += '\n'; break;
                     case 'r': result += '\r'; break;
                     case 't': result += '\t'; break;
-                    case 'v': result += '\v'; break;
 
                     case 'u':
                         // Unicode escape sequence (e.g., \uXXXX)
@@ -166,7 +164,7 @@ private:
                         {
                             auto num = data_.substr(pos_ + 1, 4);
                             try {
-                                unsigned ch = std::stoi(std::string(num), nullptr);
+                                unsigned ch = std::stoi(std::string(num), nullptr, 16);
                                 if (ch < 0x80)
                                 {
                                     result += static_cast<char>(ch);

--- a/src/data_processors/json_processor.cc
+++ b/src/data_processors/json_processor.cc
@@ -143,8 +143,6 @@ private:
             }
             else if (c == '\\')
             {
-                // TODO - Implement full JSON string unescaping
-
                 advance();
                 char esc = current_char();
                 switch (esc)
@@ -163,44 +161,42 @@ private:
                         if (pos_ + 5 < data_.length())
                         {
                             auto num = data_.substr(pos_ + 1, 4);
-                            try {
-                                auto ch = std::stoi(std::string(num), nullptr, 16);
-                                if (ch < 0x80)
-                                {
-                                    result += static_cast<char>(ch);
-                                }
-                                else if (ch < 0x800)
-                                {
-                                    result += static_cast<char>(0xC0 | (ch >> 6));
-                                    result += static_cast<char>(0x80 | (ch & 0x3F));
-                                }
-                                else if (ch < 0x10000)
-                                {
-                                    result += static_cast<char>(0xE0 | (ch >> 12));
-                                    result += static_cast<char>(0x80 | ((ch >> 6) & 0x3F));
-                                    result += static_cast<char>(0x80 | (ch & 0x3F));
-                                }
-                                else
-                                {
-                                    result += static_cast<char>(0xF0 | (ch >> 18));
-                                    result += static_cast<char>(0x80 | ((ch >> 12) & 0x3F));
-                                    result += static_cast<char>(0x80 | ((ch >> 6) & 0x3F));
-                                    result += static_cast<char>(0x80 | (ch & 0x3F));
-                                }
-                                pos_ += 4;
+                            unsigned int ch;
+                            try
+                            {
+                                ch = std::stoi(std::string(num), nullptr, 16);
                             }
-                            catch (...) {
-                                result += data_[pos_ + 1]; // Invalid number, treat as literal
-                                pos_ += 1;
+                            catch (...)
+                            {
+                                throw std::runtime_error(gul17::cat("Invalid number format in Unicode escape at position ", pos_));
                             }
+
+                            if (ch < 0x80)
+                            {
+                                result += static_cast<char>(ch);
+                            }
+                            else if (ch < 0x800)
+                            {
+                                result += static_cast<char>(0xC0 | (ch >> 6));
+                                result += static_cast<char>(0x80 | (ch & 0x3F));
+                            }
+                            else if (ch < 0x10000)
+                            {
+                                result += static_cast<char>(0xE0 | (ch >> 12));
+                                result += static_cast<char>(0x80 | ((ch >> 6) & 0x3F));
+                                result += static_cast<char>(0x80 | (ch & 0x3F));
+                            }
+                            else
+                            {
+                                // Note: JSON \uXXXX escapes only support BMP (<= 0xFFFF).
+                                throw std::runtime_error(gul17::cat("Invalid Unicode code point at position ", pos_));
+                            }
+                            pos_ += 4;
                         }
                         break;
 
                     case 'U':
-                        // Unicode escape sequence (e.g., \UXXXXXXXX)
-                        // FIXME - Unicode escape sequences not implemented yet
-                        throw std::runtime_error("Unicode escape sequences not supported");
-
+                        // TODO - Unicode escape sequence (e.g., \UXXXXXXXX) not implemented yet
                     default:
                         throw std::runtime_error(gul17::cat("Invalid escape sequence: ", esc, " at position ", pos_));
                 }
@@ -267,13 +263,27 @@ private:
             {
                 advance();
             }
-            double value = std::stod(std::string(data_.substr(start_pos, pos_ - start_pos)));
-            return DataTree(value);
+            try
+            {
+                double value = std::stod(std::string(data_.substr(start_pos, pos_ - start_pos)));
+                return DataTree(value);
+            }
+            catch (...)
+            {
+                throw std::runtime_error(gul17::cat("Invalid number format at position ", start_pos));
+            }
         }
         else
         {
-            int value = std::stoi(std::string(data_.substr(start_pos, pos_ - start_pos)));
-            return DataTree(value);
+            try
+            {
+                int value = std::stoi(std::string(data_.substr(start_pos, pos_ - start_pos)));
+                return DataTree(value);
+            }
+            catch (...)
+            {
+                throw std::runtime_error(gul17::cat("Invalid number format at position ", start_pos));
+            }
         }
     }
 
@@ -402,10 +412,12 @@ private:
 
     void serialize_array(const DataTree::Array& arr, size_t indent, size_t current_indent)
     {
+        std::string newline = indent > 0 ? "\n" : "";  // Add newlines if indenting
+
         output_ << "[";
         if (!arr.empty())
         {
-            output_ << "\n";
+            output_ << newline;
             for (size_t i = 0; i < arr.size(); ++i)
             {
                 output_ << std::string(current_indent + indent, ' ');
@@ -413,7 +425,7 @@ private:
 
                 if (i < arr.size() - 1)
                     output_ << ",";
-                output_ << "\n";
+                output_ << newline;
             }
             output_ << std::string(current_indent, ' ');
         }
@@ -422,6 +434,8 @@ private:
 
     void serialize_object(const DataTree::Object& obj, size_t indent, size_t current_indent)
     {
+        std::string newline = indent > 0 ? "\n" : "";  // Add newlines if indenting
+
         output_ << "{";
         if (!obj.empty())
         {
@@ -431,7 +445,7 @@ private:
                            [](const auto& pair) { return pair.first; });
             std::sort(keys.begin(), keys.end());
 
-            output_ << "\n";
+            output_ << newline;
             for (size_t i = 0; i < keys.size(); ++i)
             {
                 const auto& key = keys[i];
@@ -443,7 +457,7 @@ private:
 
                 if (i < keys.size() - 1)
                     output_ << ",";
-                output_ << "\n";
+                output_ << newline;
             }
             output_ << std::string(current_indent, ' ');
         }

--- a/src/data_processors/json_processor.cc
+++ b/src/data_processors/json_processor.cc
@@ -328,7 +328,7 @@ private:
 
     char next_char() const
     {
-        return pos_ + 1 < data_.size() ? data_[pos_+1] : '\0';
+        return pos_ + 1 < data_.size() ? data_[pos_ + 1] : '\0';
     }
 
     bool has_remaining_chars() const
@@ -460,13 +460,11 @@ private:
             {
                 case '"': result += "\\\""; break;
                 case '\\': result += "\\\\"; break;
-                case '\a': result += "\\a"; break;
                 case '\b': result += "\\b"; break;
                 case '\f': result += "\\f"; break;
                 case '\n': result += "\\n"; break;
                 case '\r': result += "\\r"; break;
                 case '\t': result += "\\t"; break;
-                case '\v': result += "\\v"; break;
 
                 default:
                     // escape control characters

--- a/src/data_processors/json_processor.cc
+++ b/src/data_processors/json_processor.cc
@@ -158,7 +158,7 @@ private:
 
                     case 'u':
                         // Unicode escape sequence (e.g., \uXXXX)
-                        if (pos_ + 5 < data_.length())
+                        if (pos_ + 5 <= data_.length())
                         {
                             auto num = data_.substr(pos_ + 1, 4);
                             unsigned int ch;
@@ -196,7 +196,7 @@ private:
                         break;
 
                     case 'U':
-                        // TODO - Unicode escape sequence (e.g., \UXXXXXXXX) not implemented yet
+                        throw std::runtime_error(gul17::cat("Unicode escape sequence (\\UXXXXXXXX) not supported at position ", pos_));
                     default:
                         throw std::runtime_error(gul17::cat("Invalid escape sequence: ", esc, " at position ", pos_));
                 }
@@ -476,7 +476,7 @@ private:
                     // escape control characters
                     if (static_cast<unsigned char>(c) < 0x20)
                     {
-                        char buf[7];
+                        char buf[12];
                         snprintf(buf, sizeof(buf), "\\u%04x", static_cast<unsigned char>(c));
                         result += buf;
                     }

--- a/src/data_processors/json_processor.cc
+++ b/src/data_processors/json_processor.cc
@@ -20,16 +20,16 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
- #include "gul17/data_processors.h"
+#include "gul17/data_processors.h"
 
 #include <algorithm>
 #include <sstream>
 
 using gul17::DataTree;
 
-struct JsonDataProcessorParser
+struct JsonDataParser
 {
-    JsonDataProcessorParser(const std::string_view& json_str)
+    JsonDataParser(const std::string_view& json_str)
         : data_(json_str)
     {}
 
@@ -357,75 +357,74 @@ private:
     size_t pos_{0};
 };
 
-struct JsonDataProcessorSerializer
+struct JsonDataSerializer
 {
-    static std::string serialize(
-        const DataTree& value, size_t indent)
+    JsonDataSerializer(const DataTree& tree_root)
+        : tree_root_(tree_root)
+    {}
+
+    std::string serialize(size_t indent)
     {
-        std::ostringstream oss;
-        serialize_value(oss, value, indent);
-        return oss.str();
+        serialize_value(tree_root_, indent);
+        return output_.str();
     }
 
 private:
-    static void serialize_value(
-        std::ostringstream& oss, const DataTree& value, size_t indent, size_t current_indent = 0)
+    void serialize_value(const DataTree& value, size_t indent, size_t current_indent = 0)
     {
         if (value.is_null())
         {
-            oss << "null";
+            output_ << "null";
         }
         else if (value.is_boolean())
         {
-            oss << (value.as<bool>() ? "true" : "false");
+            output_ << (value.as<bool>() ? "true" : "false");
         }
         else if (value.is_int())
         {
-            oss << std::to_string(value.as<int>());
+            output_ << std::to_string(value.as<int>());
         }
         else if (value.is_double())
         {
-            oss << std::to_string(value.as<double>());
+            output_ << std::to_string(value.as<double>());
         }
         else if (value.is_string())
         {
-            oss << "\"" << escape_string(value.as<std::string>()) << "\"";
+            output_ << "\"" << escape_string(value.as<std::string>()) << "\"";
         }
         else if (value.is_array())
         {
-            serialize_array(oss, value.as<DataTree::Array>(), indent, current_indent);
+            serialize_array(value.as<DataTree::Array>(), indent, current_indent);
         }
         else if (value.is_object())
         {
-            serialize_object(oss, value.as<DataTree::Object>(), indent, current_indent);
+            serialize_object(value.as<DataTree::Object>(), indent, current_indent);
         }
     }
 
-    static void serialize_array(
-        std::ostringstream& oss, const DataTree::Array& arr, size_t indent, size_t current_indent)
+    void serialize_array(const DataTree::Array& arr, size_t indent, size_t current_indent)
     {
-        oss << "[";
+        output_ << "[";
         if (!arr.empty())
         {
-            oss << "\n";
+            output_ << "\n";
             for (size_t i = 0; i < arr.size(); ++i)
             {
-                oss << std::string(current_indent + indent, ' ');
-                serialize_value(oss, arr[i], indent, current_indent + indent);
+                output_ << std::string(current_indent + indent, ' ');
+                serialize_value(arr[i], indent, current_indent + indent);
 
                 if (i < arr.size() - 1)
-                    oss << ",";
-                oss << "\n";
+                    output_ << ",";
+                output_ << "\n";
             }
-            oss << std::string(current_indent, ' ');
+            output_ << std::string(current_indent, ' ');
         }
-        oss << "]";
+        output_ << "]";
     }
 
-    static void serialize_object(
-        std::ostringstream& oss, const DataTree::Object& obj, size_t indent, size_t current_indent)
+    void serialize_object(const DataTree::Object& obj, size_t indent, size_t current_indent)
     {
-        oss << "{";
+        output_ << "{";
         if (!obj.empty())
         {
             // Sort keys for consistent output
@@ -434,23 +433,23 @@ private:
                            [](const auto& pair) { return pair.first; });
             std::sort(keys.begin(), keys.end());
 
-            oss << "\n";
+            output_ << "\n";
             for (size_t i = 0; i < keys.size(); ++i)
             {
                 const auto& key = keys[i];
                 const auto& val = obj.at(key);
 
-                oss << std::string(current_indent + indent, ' ');
-                oss << "\"" << escape_string(key) << "\": ";
-                serialize_value(oss, val, indent, current_indent + indent);
+                output_ << std::string(current_indent + indent, ' ');
+                output_ << "\"" << escape_string(key) << "\": ";
+                serialize_value(val, indent, current_indent + indent);
 
                 if (i < keys.size() - 1)
-                    oss << ",";
-                oss << "\n";
+                    output_ << ",";
+                output_ << "\n";
             }
-            oss << std::string(current_indent, ' ');
+            output_ << std::string(current_indent, ' ');
         }
-        oss << "}";
+        output_ << "}";
     }
 
     static std::string escape_string(const std::string& str)
@@ -488,17 +487,26 @@ private:
 
         return result;
     }
+
+private:
+    const DataTree& tree_root_;
+    std::ostringstream output_;
 };
+
+namespace gul17 {
 
 DataTree from_json_string(const std::string_view& data)
 {
-    JsonDataProcessorParser parser(data);
+    JsonDataParser parser(data);
     return parser.parse();
 }
 
 std::string to_json_string(const DataTree& value, size_t indent)
 {
-    return JsonDataProcessorSerializer::serialize(value, indent);
+    JsonDataSerializer serializer(value);
+    return serializer.serialize(indent);
 }
+
+} // namespace gul17
 
 // vi:ts=4:sw=4:sts=4:et

--- a/src/data_processors/xml_processor.cc
+++ b/src/data_processors/xml_processor.cc
@@ -1,0 +1,511 @@
+#include "gul17/data_processors.h"
+#include "gul17/cat.h"
+
+#include <algorithm>
+#include <sstream>
+
+using gul17::DataTree;
+
+struct XmlDataProcessorParser
+{
+    XmlDataProcessorParser(const std::string_view& xml_str) : data_(xml_str)
+    {}
+
+    DataTree parse() { return parse_xml_element().second; }
+
+private:
+    using KeyValuePair = std::pair<std::string, DataTree>;
+    using AttributesList = std::vector<KeyValuePair>;
+    using ChildrenList = std::vector<KeyValuePair>;
+
+    KeyValuePair parse_xml_element()
+    {
+        // Parse content
+        DataTree result;
+        skip_whitespace();
+
+        expect('<');
+
+        if (current_char() == '!')
+        {
+            // Skip comments or DOCTYPE
+            while (has_remaining_chars() && !(current_char() == '>' ))
+            {
+                advance();
+            }
+            expect('>');
+            skip_whitespace();
+            return parse_xml_element();
+        }
+
+        // Parse tag name
+        auto tag_name = std::string(parse_tag_name());
+        if (root_name_.empty())
+        {
+            root_name_ = tag_name;
+        }
+
+        // Parse attributes
+        AttributesList attributes;
+
+        while (has_remaining_chars() && current_char() != '>' && current_char() != '/')
+        {
+            skip_whitespace();
+
+            // Parse attribute name
+            auto attr_name = parse_attribute_name();
+
+            skip_whitespace();
+            expect('=');
+            skip_whitespace();
+
+            // Parse attribute value (assuming it's quoted)
+            auto attr_value = parse_attribute_value();
+
+            if (attr_value.empty())
+            {
+                attributes.emplace_back(attr_name, DataTree(nullptr));
+            }
+            else
+            {
+                attributes.emplace_back(attr_name, convert_string_to_value(attr_value));
+            }
+        }
+
+        // Parse children or text content
+        ChildrenList children;
+        std::string text_content;
+
+        if (current_char() == '/')
+        {
+            // Self-closing tag
+            advance();
+            expect('>');
+        }
+        else
+        {
+            expect('>');
+
+            // Check for nested elements vs text content
+            while (has_remaining_chars() && !(current_char() == '<' && next_char() == '/'))
+            {
+                if (current_char() == '<')
+                {
+                    // Nested element
+                    children.push_back(parse_xml_element());
+                }
+                else
+                {
+                    // Text content
+                    text_content += parse_text_content();
+                }
+                skip_whitespace();
+            }
+
+            // Parse closing tag
+            expect('<');
+            expect('/');
+            auto closing_tag = parse_tag_name();
+            expect('>');
+
+            if (closing_tag != tag_name)
+            {
+                throw std::runtime_error(gul17::cat("Mismatched tags: ", tag_name, " vs ", closing_tag));
+            }
+        }
+
+        // Determine how to represent this element - as object, array or simple value
+        if (!attributes.empty() || !children.empty())
+        {
+            // Handle arrays for multiple same-tag children / attributes
+            std::unordered_map<std::string, DataTree> obj;
+            std::unordered_map<std::string, std::vector<DataTree>> child_groups;
+
+            for (const auto& [child_tag, child_value] : children)
+            {
+                // For simplicity, assume each child is an object with its tag name
+                child_groups[child_tag].push_back(child_value);
+            }
+
+            for (auto& [child_tag, values] : child_groups)
+            {
+                if (values.size() == 1)
+                {
+                    obj[child_tag] = values[0];
+                }
+                else
+                {
+                    obj[child_tag] = DataTree(values);
+                }
+            }
+
+            for (const auto& [attr_name, attr_value] : attributes)
+            {
+                auto key = "@" + attr_name;
+                if (obj.find(key) != obj.end())
+                {
+                    throw std::runtime_error("Duplicate attribute name: " + attr_name);
+                }
+                obj[key] = attr_value;
+            }
+
+            // Add text content if any
+            if (!text_content.empty())
+            {
+                obj["#text"] = DataTree(text_content);
+            }
+
+            return std::make_pair(tag_name, DataTree(obj));
+        }
+        else if (!text_content.empty())
+        {
+            // Simple element with text content
+            // Try to convert to appropriate type
+            return std::make_pair(tag_name, convert_string_to_value(text_content));
+        }
+        else
+        {
+            // Empty element
+            return std::make_pair(tag_name, DataTree(nullptr));
+        }
+    }
+
+    std::string_view parse_attribute_name()
+    {
+        auto start_pos = pos_;
+        while (has_remaining_chars() && !std::isspace(current_char()) &&
+               current_char() != '=' && current_char() != '>' && current_char() != '/')
+        {
+            ++pos_;
+        }
+
+        return data_.substr(start_pos, pos_ - start_pos);
+    }
+
+    std::string_view parse_attribute_value()
+    {
+        char quote_char = current_char();
+        if (quote_char != '"' && quote_char != '\'')
+        {
+            throw std::runtime_error("Expected quote for attribute value");
+        }
+        advance(); // skip opening quote
+
+        auto start_pos = pos_;
+        while (has_remaining_chars() && current_char() != quote_char)
+        {
+            ++pos_;
+        }
+        auto value = data_.substr(start_pos, pos_ - start_pos);
+        expect(quote_char); // skip closing quote
+
+        return value;
+    }
+
+    std::string_view parse_tag_name()
+    {
+        auto start_pos = pos_;
+        while (has_remaining_chars() && !std::isspace(current_char()) &&
+               current_char() != '>' && current_char() != '/')
+        {
+            ++pos_;
+        }
+
+        return data_.substr(start_pos, pos_ - start_pos);
+    }
+
+    std::string_view parse_text_content()
+    {
+        size_t start_pos = pos_;
+        while (has_remaining_chars() && current_char() != '<')
+        {
+            ++pos_;
+        }
+        auto text = data_.substr(start_pos, pos_ - start_pos);
+
+        // Trim whitespace
+        auto first = text.find_first_not_of(" \t\n\r");
+        auto last = text.find_last_not_of(" \t\n\r");
+
+        if (first == std::string::npos)
+        {
+            return "";
+        }
+
+        return text.substr(first, last - first + 1);
+    }
+
+    DataTree convert_string_to_value(const std::string_view& str)
+    {
+        // Try to convert to int
+        try
+        {
+            size_t idx;
+            int int_val = std::stoi(std::string(str), &idx);
+            if (idx == str.size())
+            {
+                return DataTree(int_val);
+            }
+        }
+        catch (...) {}
+
+        // Try to convert to double
+        try
+        {
+            size_t idx;
+            double double_val = std::stod(std::string(str), &idx);
+            if (idx == str.size())
+            {
+                return DataTree(double_val);
+            }
+        }
+        catch (...) {}
+
+        // Otherwise, return as string
+        return DataTree(unescape_xml(str));
+    }
+
+    void skip_whitespace()
+    {
+        while (pos_ < data_.size() && std::isspace(data_[pos_]))
+        {
+            ++pos_;
+        }
+    }
+
+    char current_char() const
+    {
+        return pos_ < data_.size() ? data_[pos_] : '\0';
+    }
+
+    char next_char() const
+    {
+        return pos_ + 1 < data_.size() ? data_[pos_ + 1] : '\0';
+    }
+
+    bool has_remaining_chars() const
+    {
+        return pos_ < data_.size();
+    }
+
+    void advance(size_t n = 1)
+    {
+        pos_ += n;
+    }
+
+    void expect(char expected)
+    {
+        if (current_char() != expected)
+        {
+            //fprintf(stderr, "Expected '%c' but found '%c' at position %d\n", expected, current_char(), pos_);
+            throw std::runtime_error("Expected character not found");
+        }
+        advance();
+    }
+
+    static std::string unescape_xml(const std::string_view& str)
+    {
+        std::string result;
+
+        size_t i = 0;
+        while (i < str.length())
+        {
+            if (str[i] == '&')
+            {
+                if (str.compare(i, 5, "&amp;") == 0)
+                {
+                    result += '&';
+                    i += 5;
+                }
+                else if (str.compare(i, 4, "&lt;") == 0)
+                {
+                    result += '<';
+                    i += 4;
+                }
+                else if (str.compare(i, 4, "&gt;") == 0)
+                {
+                    result += '>';
+                    i += 4;
+                }
+                else if (str.compare(i, 6, "&quot;") == 0)
+                {
+                    result += '"';
+                    i += 6;
+                }
+                else if (str.compare(i, 6, "&apos;") == 0)
+                {
+                    result += '\'';
+                    i += 6;
+                }
+                else
+                {
+                    result += '&';
+                    ++i;
+                }
+            }
+            else
+            {
+                result += str[i];
+                ++i;
+            }
+        }
+
+        return result;
+    }
+
+private:
+    std::string_view data_;
+    size_t pos_{0};
+    std::string root_name_;
+};
+
+struct XmlDataProcessorSerializer
+{
+    static std::string serialize(
+        const DataTree& value, size_t indent, const std::string& root_tag_name)
+    {
+        std::ostringstream oss;
+        if (value.is_object())
+            serialize_value(oss, value, root_tag_name, indent, 0);
+        else
+            throw std::runtime_error("Root value must be an object for XML serialization");
+        return oss.str();
+    }
+
+private:
+    static void serialize_value(
+        std::ostringstream& oss, const DataTree& value, const std::string& tag_name, size_t indent, size_t current_indent = 0)
+    {
+        std::string newline = indent > 0 ? "\n" : "";  // Add newlines if indenting
+        std::string indent_str = std::string(current_indent, ' ');
+
+        std::string opening_tag = "<" + tag_name;
+        std::string closing_tag = "</" + tag_name + ">" + newline;
+
+        if (value.is_null())
+        {
+            oss << indent_str << opening_tag << "/>" << newline;
+        }
+        else if (value.is_boolean())
+        {
+            oss << indent_str << opening_tag << ">"
+                << (value.as<bool>() ? "true" : "false")
+                << closing_tag;
+        }
+        else if (value.is_int())
+        {
+            oss << indent_str << opening_tag << ">"
+                << std::to_string(value.as<int>())
+                << closing_tag;
+        }
+        else if (value.is_double())
+        {
+            oss << indent_str << opening_tag << ">"
+                << std::to_string(value.as<double>())
+                << closing_tag;
+        }
+        else if (value.is_string())
+        {
+            oss << indent_str << opening_tag << ">"
+                << escape_xml(value.as<std::string>())
+                << closing_tag;
+        }
+        else if (value.is_array())
+        {
+            const auto& array = value.as<DataTree::Array>();
+
+            for (const auto& item : array)
+            {
+                serialize_value(oss, item, tag_name, indent, current_indent);
+            }
+        }
+        else if (value.is_object())
+        {
+            const auto& obj = value.as<DataTree::Object>();
+
+            // Sort keys for consistent output
+            std::vector<DataTree::Object::key_type> keys;
+            std::transform(obj.begin(), obj.end(), std::back_inserter(keys),
+                           [](const auto& pair) { return pair.first; });
+            std::sort(keys.begin(), keys.end());
+
+            // Opening tag with attributes
+            oss << indent_str << opening_tag;
+            for (size_t i = 0; i < keys.size(); ++i)
+            {
+                const auto& key = keys[i];
+                const auto& val = obj.at(key);
+
+                if (key.rfind("@", 0) == 0)
+                {
+                    // Attribute
+                    std::string attr_name = key.substr(1); // Strip '@'
+                    oss << " " << attr_name << "=\"";
+                    if (val.is_null())
+                    {
+                        oss << "\"";
+                    }
+                    else
+                    {
+                        oss << escape_xml(val.as<std::string>()) << "\"";
+                    }
+                }
+            }
+            oss << ">";
+            oss << newline;
+
+            // Child elements and text content
+            for (size_t i = 0; i < keys.size(); ++i)
+            {
+                const auto& key = keys[i];
+                const auto& val = obj.at(key);
+
+                // Skip already handled attributes and text content handled later
+                if (key.rfind("@", 0) == 0 || key == "#text")
+                    continue;
+
+                serialize_value(oss, val, key, indent, current_indent + indent);
+            }
+
+            auto it = obj.find("#text");;
+            if (it != obj.end() && it->second.is_string())
+            {
+                // Text content
+                std::string next_indent_str = std::string(current_indent + indent, ' ');
+                oss << next_indent_str << escape_xml(it->second.as<std::string>()) << newline;
+            }
+
+            oss << indent_str;
+            oss << closing_tag;
+        }
+    }
+
+    static std::string escape_xml(const std::string_view& str)
+    {
+        std::string result;
+        for (char c : str)
+        {
+            switch (c)
+            {
+                case '&': result += "&amp;"; break;
+                case '<': result += "&lt;"; break;
+                case '>': result += "&gt;"; break;
+                case '"': result += "&quot;"; break;
+                case '\'': result += "&apos;"; break;
+                default: result += c; break;
+            }
+        }
+        return result;
+    }
+};
+
+DataTree from_xml_string(const std::string& data)
+{
+    XmlDataProcessorParser parser(data);
+    return parser.parse();
+}
+
+std::string to_xml_string(const DataTree& value, size_t indent, const std::string& root_tag_name)
+{
+    return XmlDataProcessorSerializer::serialize(value, indent, root_tag_name);
+}

--- a/src/data_processors/xml_processor.cc
+++ b/src/data_processors/xml_processor.cc
@@ -20,7 +20,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
- #include "gul17/data_processors.h"
+#include "gul17/data_processors.h"
 #include "gul17/cat.h"
 
 #include <algorithm>
@@ -28,9 +28,9 @@
 
 using gul17::DataTree;
 
-struct XmlDataProcessorParser
+struct XmlDataParser
 {
-    XmlDataProcessorParser(const std::string_view& xml_str)
+    XmlDataParser(const std::string_view& xml_str)
         : data_(xml_str)
     {}
 
@@ -378,22 +378,22 @@ private:
     std::string root_name_;
 };
 
-struct XmlDataProcessorSerializer
+struct XmlDataSerializer
 {
-    static std::string serialize(
-        const DataTree& value, size_t indent, const std::string& root_tag_name)
+    XmlDataSerializer(const DataTree& tree_root)
+        : tree_root_(tree_root)
+    {}
+
+    std::string serialize(size_t indent, const std::string& root_tag_name)
     {
-        std::ostringstream oss;
-        if (value.is_object())
-            serialize_value(oss, value, root_tag_name, indent, 0);
-        else
+        if (!tree_root_.is_object())
             throw std::runtime_error("Root value must be an object for XML serialization");
-        return oss.str();
+        serialize_value(tree_root_, root_tag_name, indent, 0);
+        return output_.str();
     }
 
 private:
-    static void serialize_value(
-        std::ostringstream& oss, const DataTree& value, const std::string& tag_name, size_t indent, size_t current_indent = 0)
+    void serialize_value(const DataTree& value, const std::string& tag_name, size_t indent, size_t current_indent = 0)
     {
         std::string newline = indent > 0 ? "\n" : "";  // Add newlines if indenting
         std::string indent_str = std::string(current_indent, ' ');
@@ -403,29 +403,29 @@ private:
 
         if (value.is_null())
         {
-            oss << indent_str << opening_tag << "/>" << newline;
+            output_ << indent_str << opening_tag << "/>" << newline;
         }
         else if (value.is_boolean())
         {
-            oss << indent_str << opening_tag << ">"
+            output_ << indent_str << opening_tag << ">"
                 << (value.as<bool>() ? "true" : "false")
                 << closing_tag;
         }
         else if (value.is_int())
         {
-            oss << indent_str << opening_tag << ">"
+            output_ << indent_str << opening_tag << ">"
                 << std::to_string(value.as<int>())
                 << closing_tag;
         }
         else if (value.is_double())
         {
-            oss << indent_str << opening_tag << ">"
+            output_ << indent_str << opening_tag << ">"
                 << std::to_string(value.as<double>())
                 << closing_tag;
         }
         else if (value.is_string())
         {
-            oss << indent_str << opening_tag << ">"
+            output_ << indent_str << opening_tag << ">"
                 << escape_xml(value.as<std::string>())
                 << closing_tag;
         }
@@ -435,7 +435,7 @@ private:
 
             for (const auto& item : array)
             {
-                serialize_value(oss, item, tag_name, indent, current_indent);
+                serialize_value(item, tag_name, indent, current_indent);
             }
         }
         else if (value.is_object())
@@ -449,7 +449,7 @@ private:
             std::sort(keys.begin(), keys.end());
 
             // Opening tag with attributes
-            oss << indent_str << opening_tag;
+            output_ << indent_str << opening_tag;
             for (size_t i = 0; i < keys.size(); ++i)
             {
                 const auto& key = keys[i];
@@ -459,19 +459,19 @@ private:
                 {
                     // Attribute
                     std::string attr_name = key.substr(1); // Strip '@'
-                    oss << " " << attr_name << "=\"";
+                    output_ << " " << attr_name << "=\"";
                     if (val.is_null())
                     {
-                        oss << "\"";
+                        output_ << "\"";
                     }
                     else
                     {
-                        oss << escape_xml(val.as<std::string>()) << "\"";
+                        output_ << escape_xml(val.as<std::string>()) << "\"";
                     }
                 }
             }
-            oss << ">";
-            oss << newline;
+            output_ << ">";
+            output_ << newline;
 
             // Child elements and text content
             for (size_t i = 0; i < keys.size(); ++i)
@@ -483,7 +483,7 @@ private:
                 if (key.rfind("@", 0) == 0 || key == "#text")
                     continue;
 
-                serialize_value(oss, val, key, indent, current_indent + indent);
+                serialize_value(val, key, indent, current_indent + indent);
             }
 
             auto it = obj.find("#text");;
@@ -491,11 +491,11 @@ private:
             {
                 // Text content
                 std::string next_indent_str = std::string(current_indent + indent, ' ');
-                oss << next_indent_str << escape_xml(it->second.as<std::string>()) << newline;
+                output_ << next_indent_str << escape_xml(it->second.as<std::string>()) << newline;
             }
 
-            oss << indent_str;
-            oss << closing_tag;
+            output_ << indent_str;
+            output_ << closing_tag;
         }
     }
 
@@ -516,17 +516,26 @@ private:
         }
         return result;
     }
+
+private:
+    const DataTree& tree_root_;
+    std::ostringstream output_;
 };
+
+namespace gul17 {
 
 DataTree from_xml_string(const std::string_view& data)
 {
-    XmlDataProcessorParser parser(data);
+    XmlDataParser parser(data);
     return parser.parse();
 }
 
 std::string to_xml_string(const DataTree& value, size_t indent, const std::string& root_tag_name)
 {
-    return XmlDataProcessorSerializer::serialize(value, indent, root_tag_name);
+    XmlDataSerializer serializer(value);
+    return serializer.serialize(indent, root_tag_name);
 }
+
+} // namespace gul17
 
 // vi:ts=4:sw=4:sts=4:et

--- a/src/data_processors/xml_processor.cc
+++ b/src/data_processors/xml_processor.cc
@@ -181,7 +181,7 @@ private:
                 }
                 else
                 {
-                    /// FIXME: Better to pass string_views directly to DataTree?
+                    /// TODO: Better to pass string_views directly to DataTree?
                     DataTree::Array text_array;
                     std::transform(
                         text_content.begin(), text_content.end(),

--- a/src/data_processors/xml_processor.cc
+++ b/src/data_processors/xml_processor.cc
@@ -25,6 +25,8 @@
 
 #include <algorithm>
 #include <sstream>
+#include <unordered_map>
+#include <vector>
 
 using gul17::DataTree;
 
@@ -48,21 +50,12 @@ private:
     {
         // Parse content
         DataTree result;
-        skip_whitespace();
+        std::vector<std::string_view> text_content;
 
+        skip_whitespace();
         expect('<');
 
-        if (current_char() == '!')
-        {
-            // Skip comments or DOCTYPE
-            while (has_remaining_chars() && !(current_char() == '>' ))
-            {
-                advance();
-            }
-            expect('>');
-            skip_whitespace();
-            return parse_xml_element();
-        }
+        strip_comment();
 
         // Parse tag name
         auto tag_name = std::string(parse_tag_name());
@@ -98,7 +91,6 @@ private:
 
         // Parse children or text content
         ChildrenList children;
-        std::string text_content;
 
         if (current_char() == '/')
         {
@@ -113,6 +105,7 @@ private:
             // Check for nested elements vs text content
             while (has_remaining_chars() && !(current_char() == '<' && next_char() == '/'))
             {
+                strip_comment();
                 if (current_char() == '<')
                 {
                     // Nested element
@@ -121,7 +114,7 @@ private:
                 else
                 {
                     // Text content
-                    text_content += parse_text_content();
+                    text_content.push_back(parse_text_content());
                 }
                 skip_whitespace();
             }
@@ -170,7 +163,7 @@ private:
                 auto key = "@" + attr_name;
                 if (obj.find(key) != obj.end())
                 {
-                    throw std::runtime_error("Duplicate attribute name: " + attr_name);
+                    throw std::runtime_error(gul17::cat("Duplicate attribute name: ", attr_name));
                 }
                 obj[key] = attr_value;
             }
@@ -178,7 +171,21 @@ private:
             // Add text content if any
             if (!text_content.empty())
             {
-                obj["#text"] = DataTree(text_content);
+                if (text_content.size() == 1)
+                {
+                    obj["#text"] = DataTree(std::string(text_content[0])); // Single text content
+                }
+                else
+                {
+                    /// FIXME: Better to pass string_views directly to DataTree?
+                    DataTree::Array text_array;
+                    std::transform(
+                        text_content.begin(), text_content.end(),
+                        std::back_inserter(text_array),
+                        [](const std::string_view& txt) { return DataTree(std::string(txt)); });
+
+                    obj["#text"] = DataTree(text_array); // Multiple text contents as array
+                }
             }
 
             return std::make_pair(tag_name, DataTree(obj));
@@ -187,12 +194,40 @@ private:
         {
             // Simple element with text content
             // Try to convert to appropriate type
-            return std::make_pair(tag_name, convert_string_to_value(text_content));
+            if (text_content.size() == 1)
+            {
+                return std::make_pair(tag_name, convert_string_to_value(text_content[0]));
+            }
+            else
+            {
+                throw std::runtime_error(gul17::cat("Multiple text contents in simple element: ", tag_name));
+            }
         }
         else
         {
             // Empty element
             return std::make_pair(tag_name, DataTree(nullptr));
+        }
+    }
+
+    void strip_comment()
+    {
+        skip_whitespace();
+
+        if (current_char() == '<' && next_char() == '!' &&
+            data_.compare(pos_, 4, "<!--") == 0)
+        {
+            pos_ += 4; // skip '<!--'
+            while (has_remaining_chars() &&
+                   data_.compare(pos_, 3, "-->") != 0)
+            {
+                ++pos_;
+            }
+            if (data_.compare(pos_, 3, "-->") == 0)
+            {
+                pos_ += 3; // skip '-->'
+            }
+            skip_whitespace();
         }
     }
 
@@ -316,8 +351,7 @@ private:
     {
         if (current_char() != expected)
         {
-            //fprintf(stderr, "Expected '%c' but found '%c' at position %d\n", expected, current_char(), pos_);
-            throw std::runtime_error("Expected character not found");
+            throw std::runtime_error(gul17::cat("Expected character not found: ", expected, " at position ", pos_));
         }
         advance();
     }

--- a/src/data_processors/xml_processor.cc
+++ b/src/data_processors/xml_processor.cc
@@ -520,7 +520,7 @@ private:
                 serialize_value(val, key, indent, current_indent + indent);
             }
 
-            auto it = obj.find("#text");;
+            auto it = obj.find("#text");
             if (it != obj.end() && it->second.is_string())
             {
                 // Text content

--- a/src/data_processors/xml_processor.cc
+++ b/src/data_processors/xml_processor.cc
@@ -1,4 +1,26 @@
-#include "gul17/data_processors.h"
+/**
+ * \file   xml_processor.cc
+ * \author Jan Behrens
+ * \date   Created on 20 November 2025
+ * \brief  Implementation of the XML data processor functions.
+ *
+ * \copyright Copyright 2018-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+ #include "gul17/data_processors.h"
 #include "gul17/cat.h"
 
 #include <algorithm>
@@ -8,10 +30,14 @@ using gul17::DataTree;
 
 struct XmlDataProcessorParser
 {
-    XmlDataProcessorParser(const std::string_view& xml_str) : data_(xml_str)
+    XmlDataProcessorParser(const std::string_view& xml_str)
+        : data_(xml_str)
     {}
 
-    DataTree parse() { return parse_xml_element().second; }
+    DataTree parse()
+    {
+        return parse_xml_element().second;
+    }
 
 private:
     using KeyValuePair = std::pair<std::string, DataTree>;
@@ -41,9 +67,7 @@ private:
         // Parse tag name
         auto tag_name = std::string(parse_tag_name());
         if (root_name_.empty())
-        {
             root_name_ = tag_name;
-        }
 
         // Parse attributes
         AttributesList attributes;
@@ -127,6 +151,7 @@ private:
                 child_groups[child_tag].push_back(child_value);
             }
 
+            // Add grouped children to object
             for (auto& [child_tag, values] : child_groups)
             {
                 if (values.size() == 1)
@@ -139,6 +164,7 @@ private:
                 }
             }
 
+            // Add attributes
             for (const auto& [attr_name, attr_value] : attributes)
             {
                 auto key = "@" + attr_name;
@@ -186,9 +212,8 @@ private:
     {
         char quote_char = current_char();
         if (quote_char != '"' && quote_char != '\'')
-        {
             throw std::runtime_error("Expected quote for attribute value");
-        }
+
         advance(); // skip opening quote
 
         auto start_pos = pos_;
@@ -228,9 +253,7 @@ private:
         auto last = text.find_last_not_of(" \t\n\r");
 
         if (first == std::string::npos)
-        {
             return "";
-        }
 
         return text.substr(first, last - first + 1);
     }
@@ -243,9 +266,7 @@ private:
             size_t idx;
             int int_val = std::stoi(std::string(str), &idx);
             if (idx == str.size())
-            {
                 return DataTree(int_val);
-            }
         }
         catch (...) {}
 
@@ -255,9 +276,7 @@ private:
             size_t idx;
             double double_val = std::stod(std::string(str), &idx);
             if (idx == str.size())
-            {
                 return DataTree(double_val);
-            }
         }
         catch (...) {}
 
@@ -499,7 +518,7 @@ private:
     }
 };
 
-DataTree from_xml_string(const std::string& data)
+DataTree from_xml_string(const std::string_view& data)
 {
     XmlDataProcessorParser parser(data);
     return parser.parse();
@@ -509,3 +528,5 @@ std::string to_xml_string(const DataTree& value, size_t indent, const std::strin
 {
     return XmlDataProcessorSerializer::serialize(value, indent, root_tag_name);
 }
+
+// vi:ts=4:sw=4:sts=4:et

--- a/src/data_processors/xml_processor.cc
+++ b/src/data_processors/xml_processor.cc
@@ -71,6 +71,10 @@ private:
 
             // Parse attribute name
             auto attr_name = parse_attribute_name();
+            if (attr_name.empty())
+            {
+                throw std::runtime_error(gul17::cat("Malformed XML: attribute name cannot be empty at position ", pos_));
+            }
 
             skip_whitespace();
             expect('=');
@@ -127,7 +131,7 @@ private:
 
             if (closing_tag != tag_name)
             {
-                throw std::runtime_error(gul17::cat("Mismatched tags: ", tag_name, " vs ", closing_tag));
+                throw std::runtime_error(gul17::cat("Mismatched tags: ", tag_name, " vs ", closing_tag, " at position ", pos_));
             }
         }
 
@@ -163,7 +167,7 @@ private:
                 auto key = "@" + attr_name;
                 if (obj.find(key) != obj.end())
                 {
-                    throw std::runtime_error(gul17::cat("Duplicate attribute name: ", attr_name));
+                    throw std::runtime_error(gul17::cat("Duplicate attribute name: ", attr_name, " at position ", pos_));
                 }
                 obj[key] = attr_value;
             }
@@ -200,7 +204,7 @@ private:
             }
             else
             {
-                throw std::runtime_error(gul17::cat("Multiple text contents in simple element: ", tag_name));
+                throw std::runtime_error(gul17::cat("Multiple text contents in simple element at position ", pos_));
             }
         }
         else
@@ -247,7 +251,7 @@ private:
     {
         char quote_char = current_char();
         if (quote_char != '"' && quote_char != '\'')
-            throw std::runtime_error("Expected quote for attribute value");
+            throw std::runtime_error(gul17::cat("Expected quote for attribute value at position ", pos_));
 
         advance(); // skip opening quote
 

--- a/src/data_processors/xml_processor.cc
+++ b/src/data_processors/xml_processor.cc
@@ -139,7 +139,7 @@ private:
         if (!attributes.empty() || !children.empty())
         {
             // Handle arrays for multiple same-tag children / attributes
-            std::unordered_map<std::string, DataTree> obj;
+            std::map<std::string, DataTree> obj;
             std::unordered_map<std::string, std::vector<DataTree>> child_groups;
 
             for (const auto& [child_tag, child_value] : children)
@@ -480,19 +480,10 @@ private:
         {
             const auto& obj = value.as<DataTree::Object>();
 
-            // Sort keys for consistent output
-            std::vector<DataTree::Object::key_type> keys;
-            std::transform(obj.begin(), obj.end(), std::back_inserter(keys),
-                           [](const auto& pair) { return pair.first; });
-            std::sort(keys.begin(), keys.end());
-
             // Opening tag with attributes
             output_ << indent_str << opening_tag;
-            for (size_t i = 0; i < keys.size(); ++i)
+            for (const auto & [key, val] : obj)
             {
-                const auto& key = keys[i];
-                const auto& val = obj.at(key);
-
                 if (key.rfind("@", 0) == 0)
                 {
                     // Attribute
@@ -512,11 +503,8 @@ private:
             output_ << newline;
 
             // Child elements and text content
-            for (size_t i = 0; i < keys.size(); ++i)
+            for (const auto & [key, val] : obj)
             {
-                const auto& key = keys[i];
-                const auto& val = obj.at(key);
-
                 // Skip already handled attributes and text content handled later
                 if (key.rfind("@", 0) == 0 || key == "#text")
                     continue;

--- a/src/data_processors/yaml_processor.cc
+++ b/src/data_processors/yaml_processor.cc
@@ -353,8 +353,6 @@ private:
 
     std::string unescape_yaml_string(const std::string_view& str)
     {
-        // TODO - Implement full YAML string unescaping
-
         std::string result;
         for (size_t i = 0; i < str.length(); ++i)
         {
@@ -384,7 +382,7 @@ private:
 
                     // Hexcode and Unicode escapes
                     case 'x':
-                        if (i + 3 < str.length())
+                        if (i + 3 <= str.length())
                         {
                             auto hex = str.substr(i + 2, 2);
                             try
@@ -402,7 +400,7 @@ private:
 
                     case 'u':
                         // Unicode escape sequence (e.g., \uXXXX)
-                        if (i + 5 < str.length())
+                        if (i + 5 <= str.length())
                         {
                             auto num = str.substr(i + 2, 4);
                             unsigned int ch;
@@ -440,7 +438,7 @@ private:
                         break;
 
                     case 'U':
-                        // TODO - Unicode escape sequence (e.g., \UXXXXXXXX) not implemented yet
+                        throw std::runtime_error(gul17::cat("Unicode escape sequence (\\UXXXXXXXX) not supported at line ", current_line_));
                     default:
                         throw std::runtime_error(gul17::cat("Invalid escape sequence: ", esc, " at line ", current_line_));
                 }

--- a/src/data_processors/yaml_processor.cc
+++ b/src/data_processors/yaml_processor.cc
@@ -553,17 +553,8 @@ private:
 
     void serialize_mapping(const DataTree::Object& obj, size_t indent, size_t current_indent)
     {
-        // Sort keys for consistent output
-        std::vector<DataTree::Object::key_type> keys;
-        std::transform(obj.begin(), obj.end(), std::back_inserter(keys),
-                        [](const auto& pair) { return pair.first; });
-        std::sort(keys.begin(), keys.end());
-
-        for (size_t i = 0; i < keys.size(); ++i)
+        for (const auto & [key, val] : obj)
         {
-            const auto& key = keys[i];
-            const auto& val = obj.at(key);
-
             output_ << std::string(current_indent, ' ') << key << ":";
 
             if (val.is_object() || val.is_array())

--- a/src/data_processors/yaml_processor.cc
+++ b/src/data_processors/yaml_processor.cc
@@ -1,0 +1,530 @@
+#include "gul17/data_processors.h"
+#include "gul17/join_split.h"
+
+#include <algorithm>
+#include <sstream>
+
+using gul17::DataTree;
+
+struct YamlDataProcessorParser
+{
+    YamlDataProcessorParser(const std::string_view& yaml_str) : data_(yaml_str)
+    {}
+
+    DataTree parse() { return parse_document(); }
+
+private:
+    DataTree parse_document()
+    {
+        // Split into lines and reset state
+        lines_.clear();
+        current_line_ = 0;
+
+#if 1
+        for (const auto & line : gul17::split_sv(data_, "\n"))
+        {
+            // Remove comments and skip empty lines
+            auto stripped = strip_comment(line);
+            if (!trim(stripped).empty())
+            {
+                lines_.emplace_back(stripped);
+            }
+        }
+#else
+        std::istringstream stream(data_);
+        std::string line;
+
+        // TODO: use string_view for efficiency
+        while (std::getline(stream, line))
+        {
+            // Remove comments and skip empty lines
+            line = strip_comment(line);
+            if (!trim(line).empty())
+            {
+                lines_.push_back(line);
+            }
+        }
+#endif
+        if (lines_.empty())
+        {
+            return DataTree(nullptr);
+        }
+
+        return parse_node();
+    }
+
+    DataTree parse_node(size_t current_indent = 0)
+    {
+        if (current_line_ >= lines_.size())
+        {
+            return DataTree(nullptr);
+        }
+
+        auto line = lines_[current_line_];
+        auto line_indent = get_indentation(line);
+        auto content = trim(line.substr(line_indent));
+
+        // Check if we're at the wrong indentation level
+        if (line_indent < current_indent)
+        {
+            return DataTree(nullptr); // Signal to go back
+        }
+
+        // Determine node type
+        if (is_sequence_item(content))
+        {
+            return parse_sequence(current_indent);
+        }
+        else if (is_mapping_item(content))
+        {
+            return parse_mapping(current_indent);
+        }
+        else
+        {
+            // Simple scalar value
+            current_line_++;
+            return parse_scalar(content);
+        }
+    }
+
+    DataTree parse_sequence(size_t current_indent)
+    {
+        DataTree::Array sequence;
+
+        while (current_line_ < lines_.size())
+        {
+            auto line = lines_[current_line_];
+            auto line_indent = get_indentation(line);
+
+            if (line_indent < current_indent)
+                break; // End of this sequence
+
+            auto content = trim(line.substr(line_indent));
+
+            if (is_sequence_item(content)) // Starts with '-'
+            {
+                // Remove the sequence marker and parse the value
+                auto item_content = trim(content.substr(1)); // Remove '-'
+                current_line_++;
+
+                // Check if this is a complex item (object or nested sequence)
+                if (current_line_ < lines_.size())
+                {
+                    auto next_indent = get_indentation(lines_[current_line_]);
+                    if (next_indent > line_indent)
+                    {
+                        // Nested structure
+                        sequence.push_back(parse_node(next_indent));
+                    }
+                    else
+                    {
+                        // Simple scalar
+                        sequence.push_back(parse_scalar(item_content));
+                    }
+                }
+                else
+                {
+                    sequence.push_back(parse_scalar(item_content));
+                }
+            }
+            else
+            {
+                break; // Not a sequence item anymore
+            }
+        }
+
+        return DataTree(sequence);
+    }
+
+    DataTree parse_mapping(size_t current_indent)
+    {
+        DataTree::Object mapping;
+
+        while (current_line_ < lines_.size())
+        {
+            auto line = lines_[current_line_];
+            auto line_indent = get_indentation(line);
+
+            if (line_indent < current_indent)
+                break; // End of this mapping
+
+            auto content = trim(line.substr(line_indent));
+
+            if (is_mapping_item(content)) // Contains ':'
+            {
+                // Parse key-value pair
+                auto colon_pos = content.find(':');
+                auto key = trim(content.substr(0, colon_pos));
+                auto value_str = trim(content.substr(colon_pos + 1));
+
+                current_line_++;
+
+                DataTree value;
+
+                if (value_str.empty())
+                {
+                    // Value might be on next lines (complex value)
+                    if (current_line_ < lines_.size())
+                    {
+                        auto next_indent = get_indentation(lines_[current_line_]);
+                        if (next_indent > line_indent)
+                        {
+                            value = parse_node(next_indent);
+                        }
+                        else
+                        {
+                            value = DataTree(nullptr); // null for empty value
+                        }
+                    }
+                    else
+                    {
+                        value = DataTree(nullptr); // null for empty value
+                    }
+                }
+                else
+                {
+                    // Simple scalar value
+                    value = parse_scalar(value_str);
+                }
+
+                mapping[std::string(key)] = value;
+            }
+            else
+            {
+                break; // Not a mapping item
+            }
+        }
+
+        return DataTree(mapping);
+    }
+
+    DataTree parse_scalar(const std::string_view& value)
+    {
+        auto trimmed = trim(value);
+
+        // Check for null
+        if (trimmed == "null" || trimmed == "~" || trimmed.empty())
+        {
+            return DataTree(nullptr);
+        }
+
+        // Check for boolean
+        if (trimmed == "true") return DataTree(true);
+        if (trimmed == "false") return DataTree(false);
+
+        // Check for number (integer)
+        if (trimmed[0] == '-' || std::isdigit(trimmed[0]))
+        {
+            try
+            {
+                if (trimmed.find('.') == std::string::npos)
+                {
+                    size_t pos;
+                    auto int_val = std::stoi(std::string(trimmed), &pos);
+                    if (pos == trimmed.length())  // Entire string was converted
+                    {
+                        return DataTree(int_val);
+                    }
+                }
+            }
+            catch (...)
+            {
+                // Not an integer, try float
+            }
+
+            // Check for number (float)
+            try
+            {
+                size_t pos;
+                auto double_val = std::stod(std::string(trimmed), &pos);
+                if (pos == trimmed.length())  // Entire string was converted
+                {
+                    return DataTree(double_val);
+                }
+            }
+            catch (...)
+            {
+                // Not a number
+            }
+        }
+
+        // Remove quotes if present and unescape
+        if ((trimmed.front() == '"' && trimmed.back() == '"') ||
+            (trimmed.front() == '\'' && trimmed.back() == '\''))
+        {
+            auto unquoted = trimmed.substr(1, trimmed.length() - 2);
+            return DataTree(unescape_yaml_string(unquoted));
+        }
+
+        // Default to string
+        return DataTree(std::string(trimmed));
+    }
+
+    size_t get_indentation(const std::string_view& line)
+    {
+        size_t i = 0;
+        while (i < line.length() && (line[i] == ' ' || line[i] == '\t'))
+        {
+            i++;
+        }
+        return i;
+    }
+
+    std::string_view strip_comment(const std::string_view& line)
+    {
+        auto comment_pos = line.find('#');
+        if (comment_pos != std::string::npos)
+        {
+            return line.substr(0, comment_pos);
+        }
+        return line;
+    }
+
+    std::string_view trim(const std::string_view& str)
+    {
+        auto start = str.find_first_not_of(" \t\n\r");
+        if (start == std::string::npos)
+            return "";
+
+        auto end = str.find_last_not_of(" \t\n\r");
+        return str.substr(start, end - start + 1);
+    }
+
+    bool is_sequence_item(const std::string_view& line)
+    {
+        auto trimmed = trim(line);
+        return !trimmed.empty() && trimmed[0] == '-';
+    }
+
+    bool is_mapping_item(const std::string_view& line)
+    {
+        return line.find(':') != std::string::npos;
+    }
+
+    std::string unescape_yaml_string(const std::string_view& str)
+    {
+        // TODO - Implement full YAML string unescaping
+
+        std::string result;
+        for (size_t i = 0; i < str.length(); ++i)
+        {
+            if (str[i] == '\\' && i + 1 < str.length())
+            {
+                switch (str[i + 1])
+                {
+                    case '"': result += '\"'; break;
+                    case '\'': result += '\''; break;
+                    case '\\': result += '\\'; break;
+                    case '/': result += '/'; break;
+                    case 'a': result += '\a'; break;
+                    case 'b': result += '\b'; break;
+                    case 'f': result += '\f'; break;
+                    case 'n': result += '\n'; break;
+                    case 'r': result += '\r'; break;
+                    case 't': result += '\t'; break;
+                    case 'v': result += '\v'; break;
+                    case ' ': result += ' '; break;
+
+                    // YAML-specific escapes
+                    case '_': result += "\xC2\xA0"; break;     // U+00A0
+                    case 'N': result += "\xC2\x85"; break;     // U+0085
+                    case 'L': result += "\xE2\x80\xA8"; break; // U+2028
+                    case 'P': result += "\xE2\x80\xA9"; break; // U+2029
+
+                    // Hexcode and Unicode escapes
+                    case 'x':
+                        if (i + 3 < str.length())
+                        {
+                            auto hex = str.substr(i + 2, 2);
+                            try {
+                                auto ch = std::stoi(std::string(hex), nullptr, 16);
+                                result += static_cast<char>(ch);
+                                i += 2;
+                            }
+                            catch (...) {
+                                result += str[i + 1]; // Invalid hex, treat as literal
+                            }
+                        }
+                        break;
+
+                    case 'u':
+                        // Unicode escape sequence (e.g., \uXXXX)
+                        if (i + 5 < str.length())
+                        {
+                            auto num = str.substr(i + 4, 4);
+                            try {
+                                auto ch = std::stoi(std::string(num), nullptr);
+                                if (ch < 0x80)
+                                {
+                                    result += static_cast<char>(ch);
+                                }
+                                else if (ch < 0x800)
+                                {
+                                    result += static_cast<char>(0xC0 | (ch >> 6));
+                                    result += static_cast<char>(0x80 | (ch & 0x3F));
+                                }
+                                else if (ch < 0x10000)
+                                {
+                                    result += static_cast<char>(0xE0 | (ch >> 12));
+                                    result += static_cast<char>(0x80 | ((ch >> 6) & 0x3F));
+                                    result += static_cast<char>(0x80 | (ch & 0x3F));
+                                }
+                                else
+                                {
+                                    result += static_cast<char>(0xF0 | (ch >> 18));
+                                    result += static_cast<char>(0x80 | ((ch >> 12) & 0x3F));
+                                    result += static_cast<char>(0x80 | ((ch >> 6) & 0x3F));
+                                    result += static_cast<char>(0x80 | (ch & 0x3F));
+                                }
+                                i += 4;
+                            }
+                            catch (...) {
+                                result += str[i + 1]; // Invalid number, treat as literal
+                            }
+                        }
+                        break;
+
+                    case 'U':
+                        // FIXME - Unicode escape sequences not implemented yet
+                        throw std::runtime_error("Unicode escape sequences not supported");
+
+                    default:
+                        // Unknown escape - treat as literal character
+                        result += str[i + 1];
+                }
+                ++i; // Skip next character after escape `\`
+            }
+            else
+            {
+                result += str[i];
+            }
+        }
+        return result;
+    }
+
+private:
+    std::string_view data_;
+    std::vector<std::string_view> lines_;
+    size_t current_line_{0};
+};
+
+struct YamlDataProcessorSerializer
+{
+    static std::string serialize(const DataTree& value, size_t indent)
+    {
+        std::ostringstream oss;
+        serialize_yaml(oss, value, indent);
+        return oss.str();
+    }
+
+private:
+    static void serialize_yaml(
+        std::ostringstream& oss, const DataTree& value, size_t indent, size_t current_indent = 0)
+    {
+        if (value.is_object())
+        {
+            serialize_mapping(oss, value.as<DataTree::Object>(), indent, current_indent);
+        }
+        else if (value.is_array())
+        {
+            serialize_sequence(oss, value.as<DataTree::Array>(), indent, current_indent);
+        }
+        else {
+            serialize_scalar(oss, value);
+        }
+    }
+
+    static void serialize_scalar(
+        std::ostringstream& oss, const DataTree& value)
+    {
+        if (value.is_null())
+        {
+            oss << "null";
+        }
+        else if (value.is_boolean())
+        {
+            oss << (value.as<bool>() ? "true" : "false");
+        }
+        else if (value.is_int())
+        {
+            oss << value.as<int>();
+        }
+        else if (value.is_double())
+        {
+            oss << value.as<double>();
+        }
+        else if (value.is_string())
+        {
+            std::string str = value.as<std::string>();
+            // Quote strings if they contain special characters
+            if (str.empty() || str.find_first_of(":#{}[]&*!|>\"'%") != std::string::npos)
+            {
+                oss << "\"" << str << "\"";
+            }
+            else
+            {
+                oss << str;
+            }
+        }
+    }
+
+    static void serialize_sequence(
+        std::ostringstream& oss, const DataTree::Array& arr, size_t indent, size_t current_indent)
+    {
+        for (const auto& item : arr)
+        {
+            oss << std::string(current_indent, ' ') << "- ";
+            if (item.is_object() || item.is_array())
+            {
+                oss << "\n";
+                serialize_yaml(oss, item, indent, current_indent + indent);
+            }
+            else
+            {
+                serialize_scalar(oss, item);
+                oss << "\n";
+            }
+        }
+    }
+
+    static void serialize_mapping(
+        std::ostringstream& oss, const DataTree::Object& obj, size_t indent, size_t current_indent)
+    {
+        // Sort keys for consistent output
+        std::vector<DataTree::Object::key_type> keys;
+        std::transform(obj.begin(), obj.end(), std::back_inserter(keys),
+                        [](const auto& pair) { return pair.first; });
+        std::sort(keys.begin(), keys.end());
+
+        for (size_t i = 0; i < keys.size(); ++i)
+        {
+            const auto& key = keys[i];
+            const auto& val = obj.at(key);
+
+            oss << std::string(current_indent, ' ') << key << ":";
+
+            if (val.is_object() || val.is_array())
+            {
+                oss << "\n";
+                serialize_yaml(oss, val, indent, current_indent + indent);
+            }
+            else
+            {
+                oss << " ";
+                serialize_scalar(oss, val);
+                oss << "\n";
+            }
+        }
+    }
+};
+
+DataTree from_yaml_string(const std::string& data)
+{
+    YamlDataProcessorParser parser(data);
+    return parser.parse();
+}
+
+std::string to_yaml_string(const DataTree& value, size_t indent)
+{
+    return YamlDataProcessorSerializer::serialize(value, indent);
+}

--- a/src/data_processors/yaml_processor.cc
+++ b/src/data_processors/yaml_processor.cc
@@ -21,6 +21,7 @@
  */
 
 #include "gul17/data_processors.h"
+#include "gul17/cat.h"
 #include "gul17/join_split.h"
 
 #include <algorithm>
@@ -110,6 +111,14 @@ private:
             {
                 // Remove the sequence marker and parse the value
                 auto item_content = trim(content.substr(1)); // Remove '-'
+                if (!item_content.empty())
+                {
+                    // Simple scalar on same line
+                    sequence.push_back(parse_scalar(item_content));
+                    current_line_++;
+                    continue;
+                }
+
                 current_line_++;
 
                 // Check if this is a complex item (object or nested sequence)
@@ -268,6 +277,8 @@ private:
         size_t i = 0;
         while (i < line.length() && (line[i] == ' ' || line[i] == '\t'))
         {
+            if (line[i] == '\t')
+                throw std::runtime_error(gul17::cat("Tabs are not allowed for indentation in YAML at line ", current_line_ + 1));
             i++;
         }
 
@@ -276,9 +287,26 @@ private:
 
     std::string_view strip_comment(const std::string_view& line)
     {
-        auto comment_pos = line.find('#');
-        if (comment_pos != std::string::npos)
-            return line.substr(0, comment_pos);
+        bool in_single_quote = false;
+        bool in_double_quote = false;
+        for (size_t i = 0; i < line.size(); ++i)
+        {
+            char c = line[i];
+            if (c == '\'' && !in_double_quote)
+            {
+                in_single_quote = !in_single_quote;
+            }
+            else if (c == '"' && !in_single_quote)
+            {
+                // Only toggle if not escaped
+                if (i == 0 || line[i-1] != '\\')
+                    in_double_quote = !in_double_quote;
+            }
+            else if (c == '#' && !in_single_quote && !in_double_quote)
+            {
+                return line.substr(0, i);
+            }
+        }
 
         return line;
     }
@@ -301,10 +329,29 @@ private:
 
     bool is_mapping_item(const std::string_view& line)
     {
-        return line.find(':') != std::string::npos;
+        // Check for a colon outside of single or double quotes
+        bool in_single_quote = false;
+        bool in_double_quote = false;
+        for (size_t i = 0; i < line.length(); ++i)
+        {
+            char c = line[i];
+            if (c == '\'' && !in_double_quote)
+            {
+                in_single_quote = !in_single_quote;
+            }
+            else if (c == '"' && !in_single_quote)
+            {
+                in_double_quote = !in_double_quote;
+            }
+            else if (c == ':' && !in_single_quote && !in_double_quote)
+            {
+                return true;
+            }
+        }
+        return false;
     }
 
-    static std::string unescape_yaml_string(const std::string_view& str)
+    std::string unescape_yaml_string(const std::string_view& str)
     {
         // TODO - Implement full YAML string unescaping
 
@@ -313,7 +360,8 @@ private:
         {
             if (str[i] == '\\' && i + 1 < str.length())
             {
-                switch (str[i + 1])
+                auto esc = str[i + 1];
+                switch (esc)
                 {
                     case '"': result += '\"'; break;
                     case '\'': result += '\''; break;
@@ -339,12 +387,14 @@ private:
                         if (i + 3 < str.length())
                         {
                             auto hex = str.substr(i + 2, 2);
-                            try {
+                            try
+                            {
                                 auto ch = std::stoi(std::string(hex), nullptr, 16);
                                 result += static_cast<char>(ch);
                                 i += 2;
                             }
-                            catch (...) {
+                            catch (...)
+                            {
                                 result += str[i + 1]; // Invalid hex, treat as literal
                             }
                         }
@@ -355,45 +405,44 @@ private:
                         if (i + 5 < str.length())
                         {
                             auto num = str.substr(i + 2, 4);
-                            try {
-                                auto ch = std::stoi(std::string(num), nullptr, 16);
-                                if (ch < 0x80)
-                                {
-                                    result += static_cast<char>(ch);
-                                }
-                                else if (ch < 0x800)
-                                {
-                                    result += static_cast<char>(0xC0 | (ch >> 6));
-                                    result += static_cast<char>(0x80 | (ch & 0x3F));
-                                }
-                                else if (ch < 0x10000)
-                                {
-                                    result += static_cast<char>(0xE0 | (ch >> 12));
-                                    result += static_cast<char>(0x80 | ((ch >> 6) & 0x3F));
-                                    result += static_cast<char>(0x80 | (ch & 0x3F));
-                                }
-                                else
-                                {
-                                    result += static_cast<char>(0xF0 | (ch >> 18));
-                                    result += static_cast<char>(0x80 | ((ch >> 12) & 0x3F));
-                                    result += static_cast<char>(0x80 | ((ch >> 6) & 0x3F));
-                                    result += static_cast<char>(0x80 | (ch & 0x3F));
-                                }
-                                i += 4;
+                            unsigned int ch;
+                            try
+                            {
+                                ch = std::stoi(std::string(num), nullptr, 16);
                             }
-                            catch (...) {
-                                result += str[i + 1]; // Invalid number, treat as literal
+                            catch (...)
+                            {
+                                throw std::runtime_error(gul17::cat("Invalid number format in Unicode escape at line ", current_line_));
                             }
+
+                            if (ch < 0x80)
+                            {
+                                result += static_cast<char>(ch);
+                            }
+                            else if (ch < 0x800)
+                            {
+                                result += static_cast<char>(0xC0 | (ch >> 6));
+                                result += static_cast<char>(0x80 | (ch & 0x3F));
+                            }
+                            else if (ch < 0x10000)
+                            {
+                                result += static_cast<char>(0xE0 | (ch >> 12));
+                                result += static_cast<char>(0x80 | ((ch >> 6) & 0x3F));
+                                result += static_cast<char>(0x80 | (ch & 0x3F));
+                            }
+                            else
+                            {
+                                // Note: JSON \uXXXX escapes only support BMP (<= 0xFFFF).
+                                throw std::runtime_error(gul17::cat("Invalid Unicode code point at line ", current_line_));
+                            }
+                            i += 4;
                         }
                         break;
 
                     case 'U':
-                        // FIXME - Unicode escape sequences not implemented yet
-                        throw std::runtime_error("Unicode escape sequences not supported");
-
+                        // TODO - Unicode escape sequence (e.g., \UXXXXXXXX) not implemented yet
                     default:
-                        // Unknown escape - treat as literal character
-                        result += str[i + 1];
+                        throw std::runtime_error(gul17::cat("Invalid escape sequence: ", esc, " at line ", current_line_));
                 }
                 ++i; // Skip next character after escape `\`
             }
@@ -467,7 +516,15 @@ private:
             // Quote strings if they contain special characters
             if (str.empty() || str.find_first_of(":#{}[]&*!|>\"'%") != std::string::npos)
             {
-                output_ << "\"" << str << "\"";
+                output_ << "\"";
+                for (char c : str)
+                {
+                    if (c == '"')
+                        output_ << "\\\"";
+                    else
+                        output_ << c;
+                }
+                output_ << "\"";
             }
             else
             {

--- a/src/data_processors/yaml_processor.cc
+++ b/src/data_processors/yaml_processor.cc
@@ -28,9 +28,9 @@
 
 using gul17::DataTree;
 
-struct YamlDataProcessorParser
+struct YamlDataParser
 {
-    YamlDataProcessorParser(const std::string_view& yaml_str)
+    YamlDataParser(const std::string_view& yaml_str)
         : data_(yaml_str)
     {}
 
@@ -304,7 +304,7 @@ private:
         return line.find(':') != std::string::npos;
     }
 
-    std::string unescape_yaml_string(const std::string_view& str)
+    static std::string unescape_yaml_string(const std::string_view& str)
     {
         // TODO - Implement full YAML string unescaping
 
@@ -412,53 +412,54 @@ private:
     size_t current_line_{0};
 };
 
-struct YamlDataProcessorSerializer
+struct YamlDataSerializer
 {
-    static std::string serialize(const DataTree& value, size_t indent)
+    YamlDataSerializer(const DataTree& tree_root)
+        : tree_root_(tree_root)
+    {}
+
+    std::string serialize(size_t indent)
     {
         if (indent == 0)
             throw std::runtime_error("Indentation must be greater than zero for YAML serialization");
-        std::ostringstream oss;
-        serialize_yaml(oss, value, indent);
-        return oss.str();
+        serialize_yaml(tree_root_, indent);
+        return output_.str();
     }
 
 private:
-    static void serialize_yaml(
-        std::ostringstream& oss, const DataTree& value, size_t indent, size_t current_indent = 0)
+    void serialize_yaml(const DataTree& value, size_t indent, size_t current_indent = 0)
     {
         if (value.is_object())
         {
-            serialize_mapping(oss, value.as<DataTree::Object>(), indent, current_indent);
+            serialize_mapping(value.as<DataTree::Object>(), indent, current_indent);
         }
         else if (value.is_array())
         {
-            serialize_sequence(oss, value.as<DataTree::Array>(), indent, current_indent);
+            serialize_sequence(value.as<DataTree::Array>(), indent, current_indent);
         }
         else
         {
-            serialize_scalar(oss, value);
+            serialize_scalar(value);
         }
     }
 
-    static void serialize_scalar(
-        std::ostringstream& oss, const DataTree& value)
+    void serialize_scalar(const DataTree& value)
     {
         if (value.is_null())
         {
-            oss << "null";
+            output_ << "null";
         }
         else if (value.is_boolean())
         {
-            oss << (value.as<bool>() ? "true" : "false");
+            output_ << (value.as<bool>() ? "true" : "false");
         }
         else if (value.is_int())
         {
-            oss << value.as<int>();
+            output_ << value.as<int>();
         }
         else if (value.is_double())
         {
-            oss << value.as<double>();
+            output_ << value.as<double>();
         }
         else if (value.is_string())
         {
@@ -466,36 +467,34 @@ private:
             // Quote strings if they contain special characters
             if (str.empty() || str.find_first_of(":#{}[]&*!|>\"'%") != std::string::npos)
             {
-                oss << "\"" << str << "\"";
+                output_ << "\"" << str << "\"";
             }
             else
             {
-                oss << str;
+                output_ << str;
             }
         }
     }
 
-    static void serialize_sequence(
-        std::ostringstream& oss, const DataTree::Array& arr, size_t indent, size_t current_indent)
+    void serialize_sequence(const DataTree::Array& arr, size_t indent, size_t current_indent)
     {
         for (const auto& item : arr)
         {
-            oss << std::string(current_indent, ' ') << "- ";
+            output_ << std::string(current_indent, ' ') << "- ";
             if (item.is_object() || item.is_array())
             {
-                oss << "\n";
-                serialize_yaml(oss, item, indent, current_indent + indent);
+                output_ << "\n";
+                serialize_yaml(item, indent, current_indent + indent);
             }
             else
             {
-                serialize_scalar(oss, item);
-                oss << "\n";
+                serialize_scalar(item);
+                output_ << "\n";
             }
         }
     }
 
-    static void serialize_mapping(
-        std::ostringstream& oss, const DataTree::Object& obj, size_t indent, size_t current_indent)
+    void serialize_mapping(const DataTree::Object& obj, size_t indent, size_t current_indent)
     {
         // Sort keys for consistent output
         std::vector<DataTree::Object::key_type> keys;
@@ -508,32 +507,41 @@ private:
             const auto& key = keys[i];
             const auto& val = obj.at(key);
 
-            oss << std::string(current_indent, ' ') << key << ":";
+            output_ << std::string(current_indent, ' ') << key << ":";
 
             if (val.is_object() || val.is_array())
             {
-                oss << "\n";
-                serialize_yaml(oss, val, indent, current_indent + indent);
+                output_ << "\n";
+                serialize_yaml(val, indent, current_indent + indent);
             }
             else
             {
-                oss << " ";
-                serialize_scalar(oss, val);
-                oss << "\n";
+                output_ << " ";
+                serialize_scalar(val);
+                output_ << "\n";
             }
         }
     }
+
+private:
+    const DataTree& tree_root_;
+    std::ostringstream output_;
 };
+
+namespace gul17 {
 
 DataTree from_yaml_string(const std::string_view& data)
 {
-    YamlDataProcessorParser parser(data);
+    YamlDataParser parser(data);
     return parser.parse();
 }
 
 std::string to_yaml_string(const DataTree& value, size_t indent)
 {
-    return YamlDataProcessorSerializer::serialize(value, indent);
+    YamlDataSerializer serializer(value);
+    return serializer.serialize(indent);
 }
+
+} // namespace gul17
 
 // vi:ts=4:sw=4:sts=4:et

--- a/src/data_processors/yaml_processor.cc
+++ b/src/data_processors/yaml_processor.cc
@@ -1,3 +1,25 @@
+/**
+ * \file   yaml_processor.cc
+ * \author Jan Behrens
+ * \date   Created on 20 November 2025
+ * \brief  Implementation of the YAML data processor functions.
+ *
+ * \copyright Copyright 2018-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
 #include "gul17/data_processors.h"
 #include "gul17/join_split.h"
 
@@ -8,10 +30,14 @@ using gul17::DataTree;
 
 struct YamlDataProcessorParser
 {
-    YamlDataProcessorParser(const std::string_view& yaml_str) : data_(yaml_str)
+    YamlDataProcessorParser(const std::string_view& yaml_str)
+        : data_(yaml_str)
     {}
 
-    DataTree parse() { return parse_document(); }
+    DataTree parse()
+    {
+        return parse_document();
+    }
 
 private:
     DataTree parse_document()
@@ -20,7 +46,6 @@ private:
         lines_.clear();
         current_line_ = 0;
 
-#if 1
         for (const auto & line : gul17::split_sv(data_, "\n"))
         {
             // Remove comments and skip empty lines
@@ -30,25 +55,9 @@ private:
                 lines_.emplace_back(stripped);
             }
         }
-#else
-        std::istringstream stream(data_);
-        std::string line;
 
-        // TODO: use string_view for efficiency
-        while (std::getline(stream, line))
-        {
-            // Remove comments and skip empty lines
-            line = strip_comment(line);
-            if (!trim(line).empty())
-            {
-                lines_.push_back(line);
-            }
-        }
-#endif
         if (lines_.empty())
-        {
             return DataTree(nullptr);
-        }
 
         return parse_node();
     }
@@ -56,9 +65,7 @@ private:
     DataTree parse_node(size_t current_indent = 0)
     {
         if (current_line_ >= lines_.size())
-        {
             return DataTree(nullptr);
-        }
 
         auto line = lines_[current_line_];
         auto line_indent = get_indentation(line);
@@ -66,9 +73,7 @@ private:
 
         // Check if we're at the wrong indentation level
         if (line_indent < current_indent)
-        {
             return DataTree(nullptr); // Signal to go back
-        }
 
         // Determine node type
         if (is_sequence_item(content))
@@ -204,9 +209,7 @@ private:
 
         // Check for null
         if (trimmed == "null" || trimmed == "~" || trimmed.empty())
-        {
             return DataTree(nullptr);
-        }
 
         // Check for boolean
         if (trimmed == "true") return DataTree(true);
@@ -267,6 +270,7 @@ private:
         {
             i++;
         }
+
         return i;
     }
 
@@ -274,9 +278,8 @@ private:
     {
         auto comment_pos = line.find('#');
         if (comment_pos != std::string::npos)
-        {
             return line.substr(0, comment_pos);
-        }
+
         return line;
     }
 
@@ -399,6 +402,7 @@ private:
                 result += str[i];
             }
         }
+
         return result;
     }
 
@@ -412,6 +416,8 @@ struct YamlDataProcessorSerializer
 {
     static std::string serialize(const DataTree& value, size_t indent)
     {
+        if (indent == 0)
+            throw std::runtime_error("Indentation must be greater than zero for YAML serialization");
         std::ostringstream oss;
         serialize_yaml(oss, value, indent);
         return oss.str();
@@ -429,7 +435,8 @@ private:
         {
             serialize_sequence(oss, value.as<DataTree::Array>(), indent, current_indent);
         }
-        else {
+        else
+        {
             serialize_scalar(oss, value);
         }
     }
@@ -518,7 +525,7 @@ private:
     }
 };
 
-DataTree from_yaml_string(const std::string& data)
+DataTree from_yaml_string(const std::string_view& data)
 {
     YamlDataProcessorParser parser(data);
     return parser.parse();
@@ -528,3 +535,5 @@ std::string to_yaml_string(const DataTree& value, size_t indent)
 {
     return YamlDataProcessorSerializer::serialize(value, indent);
 }
+
+// vi:ts=4:sw=4:sts=4:et

--- a/src/data_processors/yaml_processor.cc
+++ b/src/data_processors/yaml_processor.cc
@@ -354,9 +354,9 @@ private:
                         // Unicode escape sequence (e.g., \uXXXX)
                         if (i + 5 < str.length())
                         {
-                            auto num = str.substr(i + 4, 4);
+                            auto num = str.substr(i + 2, 4);
                             try {
-                                auto ch = std::stoi(std::string(num), nullptr);
+                                auto ch = std::stoi(std::string(num), nullptr, 16);
                                 if (ch < 0x80)
                                 {
                                     result += static_cast<char>(ch);

--- a/src/data_processors/yaml_processor.cc
+++ b/src/data_processors/yaml_processor.cc
@@ -329,10 +329,10 @@ private:
                     case ' ': result += ' '; break;
 
                     // YAML-specific escapes
-                    case '_': result += "\xC2\xA0"; break;     // U+00A0
-                    case 'N': result += "\xC2\x85"; break;     // U+0085
-                    case 'L': result += "\xE2\x80\xA8"; break; // U+2028
-                    case 'P': result += "\xE2\x80\xA9"; break; // U+2029
+                    case '_': result += u8"\u00A0"; break;     // U+00A0 (non-breaking space)
+                    case 'N': result += u8"\u0085"; break;     // U+0085 (next line)
+                    case 'L': result += u8"\u2028"; break;     // U+2028 (line separator)
+                    case 'P': result += u8"\u2029"; break;     // U+2029 (paragraph separator)
 
                     // Hexcode and Unicode escapes
                     case 'x':

--- a/src/meson.build
+++ b/src/meson.build
@@ -10,6 +10,9 @@ libgul_src = files([
     'to_number.cc',
     'Trigger.cc',
     'trim.cc',
+    'data_processors/json_processor.cc',
+    'data_processors/xml_processor.cc',
+    'data_processors/yaml_processor.cc',
 ])
 
 inc += include_directories('.')

--- a/tests/data_processors/test_json_processor.cc
+++ b/tests/data_processors/test_json_processor.cc
@@ -89,7 +89,7 @@ R"({
     REQUIRE(tree["key2"].as<std::string>() == "\"value\\2\"");
 
     REQUIRE(tree["key3"].is_string());
-    REQUIRE(tree["key3"].as<std::string>() == " \"");
+    REQUIRE(tree["key3"].as<std::string>() == "24");
 }
 
 TEST_CASE("JsonDataProcessor: JSON parsing with errors", "[JsonDataProcessor]")

--- a/tests/data_processors/test_json_processor.cc
+++ b/tests/data_processors/test_json_processor.cc
@@ -26,8 +26,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 
-#if 0 // Temporarily disable all tests to focus on test_func()
-
 using gul17::DataTree;
 using gul17::from_json_string;
 using gul17::to_json_string;
@@ -130,5 +128,3 @@ R"({
     auto json_str = to_json_string(tree, 2);
     REQUIRE(json_str == expected_json);
 }
-
-#endif

--- a/tests/data_processors/test_json_processor.cc
+++ b/tests/data_processors/test_json_processor.cc
@@ -26,6 +26,8 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 
+#if 0 // Temporarily disable all tests to focus on test_func()
+
 using gul17::DataTree;
 using gul17::from_json_string;
 using gul17::to_json_string;
@@ -128,3 +130,5 @@ R"({
     auto json_str = to_json_string(tree, 2);
     REQUIRE(json_str == expected_json);
 }
+
+#endif

--- a/tests/data_processors/test_json_processor.cc
+++ b/tests/data_processors/test_json_processor.cc
@@ -1,0 +1,130 @@
+/**
+ * \file   test_JsonDataProcessor.cc
+ * \author Jan Behrens
+ * \date   Created on November 19, 2025
+ * \brief  Test suite for the JsonDataProcessor class.
+ *
+ * \copyright Copyright 2019-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "gul17/data_processors.h"
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+using gul17::DataTree;
+using gul17::from_json_string;
+using gul17::to_json_string;
+
+TEST_CASE("JsonDataProcessor: JSON parsing", "[JsonDataProcessor]")
+{
+    auto tree = from_json_string(
+        R"({"key1": "value1", "key2": 42, "key3": [1, 2, 3], "key4": {"nestedKey": 3.1415}, "key5": null})");
+
+    REQUIRE(tree["key1"].is_string());
+    REQUIRE(tree["key1"].as<std::string>() == "value1");
+
+    REQUIRE(tree["key2"].is_number());
+    REQUIRE(tree["key2"].as<int>() == 42);
+
+    REQUIRE(tree["key3"].is_array());
+    REQUIRE(tree["key3"].size() == 3);
+    REQUIRE(tree["key3"][0].as<int>() == 1);
+    REQUIRE(tree["key3"][1].as<int>() == 2);
+    REQUIRE(tree["key3"][2].as<int>() == 3);
+
+    REQUIRE(tree["key4"].is_object());
+    REQUIRE(tree["key4"]["nestedKey"].is_double());
+    REQUIRE(tree["key4"]["nestedKey"].as<double>() == Catch::Approx(3.1415));
+
+    REQUIRE(tree["key5"].is_null());
+
+    REQUIRE(tree.has_key("invalid") == false);
+    REQUIRE(tree["invalid"].is_empty());
+}
+
+TEST_CASE("JsonDataProcessor: JSON parsing with comments", "[JsonDataProcessor]")
+{
+    auto tree = from_json_string(
+R"({
+    /* ignored comment */
+    "key1": "value1",
+    "key2": 42
+})");
+
+    REQUIRE(tree["key1"].is_string());
+    REQUIRE(tree["key1"].as<std::string>() == "value1");
+
+    REQUIRE(tree["key2"].is_number());
+    REQUIRE(tree["key2"].as<int>() == 42);
+}
+
+TEST_CASE("JsonDataProcessor: JSON parsing with escape sequences", "[JsonDataProcessor]")
+{
+    auto tree = from_json_string(
+R"({
+    "key1": "\nvalue1\t",
+    "key2": "\"value\\2\"",
+    "key3": "\u0032\u0034"
+})");
+
+    REQUIRE(tree["key1"].is_string());
+    REQUIRE(tree["key1"].as<std::string>() == "\nvalue1\t");
+
+    REQUIRE(tree["key2"].is_string());
+    REQUIRE(tree["key2"].as<std::string>() == "\"value\\2\"");
+
+    REQUIRE(tree["key3"].is_string());
+    REQUIRE(tree["key3"].as<std::string>() == " \"");
+}
+
+TEST_CASE("JsonDataProcessor: JSON parsing with errors", "[JsonDataProcessor]")
+{
+    REQUIRE_THROWS(from_json_string(R"({"key1": "value1", "key2": 42, )")); // Trailing comma
+    REQUIRE_THROWS(from_json_string(R"({"key1": "value1" "key2": 42})")); // Missing comma
+    REQUIRE_THROWS(from_json_string(R"({"key1": "value1", "key2": [1, 2, })")); // Trailing comma in array
+    REQUIRE_THROWS(from_json_string(R"({"key1": "value1", "key2": 42)")); // Missing closing brace
+}
+
+TEST_CASE("JsonDataProcessor: JSON serialization", "[JsonDataProcessor]")
+{
+    auto tree = DataTree::make_object();
+
+    tree["key1"] = "value1";
+    tree["key2"] = 42;
+    tree["key3"] = DataTree::Array{1, 2, 3};
+    tree["key4"] = DataTree::Object{{"nestedKey", nullptr}};
+    tree["key5"] = nullptr;
+
+    std::string expected_json =
+R"({
+  "key1": "value1",
+  "key2": 42,
+  "key3": [
+    1,
+    2,
+    3
+  ],
+  "key4": {
+    "nestedKey": null
+  },
+  "key5": null
+})";
+
+    auto json_str = to_json_string(tree, 2);
+    REQUIRE(json_str == expected_json);
+}

--- a/tests/data_processors/test_json_processor.cc
+++ b/tests/data_processors/test_json_processor.cc
@@ -1,8 +1,8 @@
 /**
- * \file   test_JsonDataProcessor.cc
+ * \file   test_json_processor.cc
  * \author Jan Behrens
  * \date   Created on November 19, 2025
- * \brief  Test suite for the JsonDataProcessor class.
+ * \brief  Test suite for the JsonProcessor class.
  *
  * \copyright Copyright 2019-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
@@ -30,7 +30,7 @@ using gul17::DataTree;
 using gul17::from_json_string;
 using gul17::to_json_string;
 
-TEST_CASE("JsonDataProcessor: JSON parsing", "[JsonDataProcessor]")
+TEST_CASE("JsonProcessor: JSON parsing", "[JsonProcessor]")
 {
     auto tree = from_json_string(
         R"({"key1": "value1", "key2": 42, "key3": [1, 2, 3], "key4": {"nestedKey": 3.1415}, "key5": null})");
@@ -57,7 +57,7 @@ TEST_CASE("JsonDataProcessor: JSON parsing", "[JsonDataProcessor]")
     REQUIRE(tree["invalid"].is_empty());
 }
 
-TEST_CASE("JsonDataProcessor: JSON parsing with comments", "[JsonDataProcessor]")
+TEST_CASE("JsonProcessor: JSON parsing with comments", "[JsonProcessor]")
 {
     auto tree = from_json_string(
 R"({
@@ -73,7 +73,7 @@ R"({
     REQUIRE(tree["key2"].as<int>() == 42);
 }
 
-TEST_CASE("JsonDataProcessor: JSON parsing with escape sequences", "[JsonDataProcessor]")
+TEST_CASE("JsonProcessor: JSON parsing with escape sequences", "[JsonProcessor]")
 {
     auto tree = from_json_string(
 R"({
@@ -92,7 +92,7 @@ R"({
     REQUIRE(tree["key3"].as<std::string>() == "24");
 }
 
-TEST_CASE("JsonDataProcessor: JSON parsing with errors", "[JsonDataProcessor]")
+TEST_CASE("JsonProcessor: JSON parsing with errors", "[JsonProcessor]")
 {
     REQUIRE_THROWS(from_json_string(R"({"key1": "value1", "key2": 42, )")); // Trailing comma
     REQUIRE_THROWS(from_json_string(R"({"key1": "value1" "key2": 42})")); // Missing comma
@@ -100,7 +100,7 @@ TEST_CASE("JsonDataProcessor: JSON parsing with errors", "[JsonDataProcessor]")
     REQUIRE_THROWS(from_json_string(R"({"key1": "value1", "key2": 42)")); // Missing closing brace
 }
 
-TEST_CASE("JsonDataProcessor: JSON serialization", "[JsonDataProcessor]")
+TEST_CASE("JsonProcessor: JSON serialization", "[JsonProcessor]")
 {
     auto tree = DataTree::make_object();
 

--- a/tests/data_processors/test_xml_processor.cc
+++ b/tests/data_processors/test_xml_processor.cc
@@ -26,6 +26,8 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 
+#if 0 // Temporarily disable all tests to focus on test_func()
+
 using gul17::DataTree;
 using gul17::from_xml_string;
 using gul17::to_xml_string;
@@ -218,3 +220,5 @@ R"(
     REQUIRE(tree["LIST"]["PERM"][0]["MASK"].as<std::string>() == "mask");
     // Second PERM omitted for brevity
 }
+
+#endif

--- a/tests/data_processors/test_xml_processor.cc
+++ b/tests/data_processors/test_xml_processor.cc
@@ -71,10 +71,12 @@ TEST_CASE("XmlDataProcessor: XML parsing with attributes and comments", "[XmlDat
 {
     auto tree = from_xml_string(
 R"(<root>
+    TEXT CONTENT 1
     <!-- ignored comment -->
+    TEXT CONTENT 2
     <key1 attr1="k1a1">value1</key1>
     <key2 attr1="k2a1" attr2="k2a2" attr3=""></key2>
-    TEXT CONTENT
+    TEXT CONTENT 3
 </root>)");
 
     REQUIRE(tree["key1"].is_object());
@@ -91,8 +93,11 @@ R"(<root>
     REQUIRE(tree["key2"]["@attr2"].as<std::string>() == "k2a2");
     REQUIRE(tree["key2"]["@attr3"].is_null());
 
-    REQUIRE(tree["#text"].is_string());
-    REQUIRE(tree["#text"].as<std::string>() == "TEXT CONTENT");
+    REQUIRE(tree["#text"].is_array());
+    REQUIRE(tree["#text"].size() == 3);
+    REQUIRE(tree["#text"][0].as<std::string>() == "TEXT CONTENT 1");
+    REQUIRE(tree["#text"][1].as<std::string>() == "TEXT CONTENT 2");
+    REQUIRE(tree["#text"][2].as<std::string>() == "TEXT CONTENT 3");
 }
 
 TEST_CASE("XmlDataProcessor: XML parsing with escape sequences", "[XmlDataProcessor]")

--- a/tests/data_processors/test_xml_processor.cc
+++ b/tests/data_processors/test_xml_processor.cc
@@ -26,8 +26,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 
-#if 0 // Temporarily disable all tests to focus on test_func()
-
 using gul17::DataTree;
 using gul17::from_xml_string;
 using gul17::to_xml_string;
@@ -220,5 +218,3 @@ R"(
     REQUIRE(tree["LIST"]["PERM"][0]["MASK"].as<std::string>() == "mask");
     // Second PERM omitted for brevity
 }
-
-#endif

--- a/tests/data_processors/test_xml_processor.cc
+++ b/tests/data_processors/test_xml_processor.cc
@@ -1,0 +1,220 @@
+/**
+ * \file   test_XmlDataProcessor.cc
+ * \author Jan Behrens
+ * \date   Created on November 19, 2025
+ * \brief  Test suite for the XmlDataProcessor class.
+ *
+ * \copyright Copyright 2019-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "gul17/data_processors.h"
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+using gul17::DataTree;
+using gul17::from_xml_string;
+using gul17::to_xml_string;
+
+TEST_CASE("XmlDataProcessor: XML parsing", "[XmlDataProcessor]")
+{
+    auto tree = from_xml_string(
+R"(<root>
+    <key1>value1</key1>
+    <key2>42</key2>
+    <key3>1</key3>
+    <key3>2</key3>
+    <key3>3</key3>
+    <key4>
+        <nestedKey>3.1415</nestedKey>
+    </key4>
+    <key5/>
+</root>)");
+
+    REQUIRE(tree["key1"].is_string());
+    REQUIRE(tree["key1"].as<std::string>() == "value1");
+
+    REQUIRE(tree["key2"].is_number());
+    REQUIRE(tree["key2"].as<int>() == 42);
+
+    REQUIRE(tree["key3"].is_array());
+    REQUIRE(tree["key3"].size() == 3);
+    REQUIRE(tree["key3"][0].as<int>() == 1);
+    REQUIRE(tree["key3"][1].as<int>() == 2);
+    REQUIRE(tree["key3"][2].as<int>() == 3);
+
+    REQUIRE(tree["key4"].is_object());
+    REQUIRE(tree["key4"]["nestedKey"].is_double());
+    REQUIRE(tree["key4"]["nestedKey"].as<double>() == Catch::Approx(3.1415));
+
+    REQUIRE(tree["key5"].is_null());
+
+    REQUIRE(tree.has_key("invalid") == false);
+    REQUIRE(tree["invalid"].is_empty());
+}
+
+TEST_CASE("XmlDataProcessor: XML parsing with attributes and comments", "[XmlDataProcessor]")
+{
+    auto tree = from_xml_string(
+R"(<root>
+    <!-- ignored comment -->
+    <key1 attr1="k1a1">value1</key1>
+    <key2 attr1="k2a1" attr2="k2a2" attr3=""></key2>
+    TEXT CONTENT
+</root>)");
+
+    REQUIRE(tree["key1"].is_object());
+    REQUIRE(tree["key1"]["#text"].is_string());
+    REQUIRE(tree["key1"]["#text"].as<std::string>() == "value1");
+    REQUIRE(tree["key1"]["@attr1"].is_string());
+    REQUIRE(tree["key1"]["@attr1"].as<std::string>() == "k1a1");
+
+    REQUIRE(tree["key2"].is_object());
+    REQUIRE(tree["key2"]["#text"].is_empty());
+    REQUIRE(tree["key2"]["@attr1"].is_string());
+    REQUIRE(tree["key2"]["@attr1"].as<std::string>() == "k2a1");
+    REQUIRE(tree["key2"]["@attr2"].is_string());
+    REQUIRE(tree["key2"]["@attr2"].as<std::string>() == "k2a2");
+    REQUIRE(tree["key2"]["@attr3"].is_null());
+
+    REQUIRE(tree["#text"].is_string());
+    REQUIRE(tree["#text"].as<std::string>() == "TEXT CONTENT");
+}
+
+TEST_CASE("XmlDataProcessor: XML parsing with escape sequences", "[XmlDataProcessor]")
+{
+    auto tree = from_xml_string(
+R"(
+<root>
+    <key1>&gt;&lt;&amp;&quot;&apos;</key1>
+</root>
+)");
+
+    REQUIRE(tree["key1"].is_string());
+    REQUIRE(tree["key1"].as<std::string>() == "><&\"'");
+}
+
+TEST_CASE("XmlDataProcessor: XML parsing with errors", "[XmlDataProcessor]")
+{
+    REQUIRE_THROWS(from_xml_string(R"(<root><key1></root>)")); // Missing closing tag
+    REQUIRE_THROWS(from_xml_string(R"(<root><key1></key2></root>)")); // Mismatched closing tag
+    REQUIRE_THROWS(from_xml_string(R"(<root><key1 attr1 attr2/></root>)")); // Malformed attribute
+    REQUIRE_THROWS(from_xml_string(R"(<root><key1 attr1="1" attr1="2"/></root>)")); // Duplicate attribute
+}
+
+TEST_CASE("XmlDataProcessor: XML serialization", "[XmlDataProcessor]")
+{
+    auto tree = DataTree::make_object();
+
+    tree["key1"] = "value1";
+    tree["key2"] = 42;
+    tree["key3"] = DataTree::Array{1, 2, 3};
+    tree["key4"] = DataTree::Object{{"nestedKey", nullptr}};
+    tree["key5"] = nullptr;
+
+    std::string expected_xml =
+R"(<root>
+    <key1>value1</key1>
+    <key2>42</key2>
+    <key3>1</key3>
+    <key3>2</key3>
+    <key3>3</key3>
+    <key4>
+        <nestedKey/>
+    </key4>
+    <key5/>
+</root>
+)";
+
+    auto xml_str = to_xml_string(tree, 4);
+    REQUIRE(xml_str == expected_xml);
+}
+
+TEST_CASE("XmlDataProcessor: XML serialization with attributes", "[XmlDataProcessor]")
+{
+    auto tree = DataTree::make_object();
+
+    tree["key1"]["#text"] = "value1";
+    tree["key1"]["@attr1"] = "k1a1";
+    tree["key2"]["#text"] = nullptr;
+    tree["key2"]["@attr1"] = "k2a1";
+    tree["key2"]["@attr2"] = "k2a2";
+    tree["key2"]["@attr3"] = nullptr;
+    tree["#text"] = "TEXT CONTENT";
+
+    std::string expected_xml =
+R"(<root>
+    <key1 attr1="k1a1">
+        value1
+    </key1>
+    <key2 attr1="k2a1" attr2="k2a2" attr3="">
+    </key2>
+    TEXT CONTENT
+</root>
+)";
+
+    auto xml_str = to_xml_string(tree, 4);
+    REQUIRE(xml_str == expected_xml);
+}
+
+TEST_CASE("XmlDataProcessor: XML parsing of SVR.AUTH string", "[XmlDataProcessor]")
+{
+    auto tree = from_xml_string(
+R"(
+<AUTH>
+<OPER>         uid </OPER>         # set operator User  ID
+<OPER_GROUP>   gid </OPER_GROUP>   # set operator Group ID
+<XPERT>        uid </XPERT>        # set expert   User  ID
+<XPERT_GROUP>  gid </XPERT_GROUP>  # set expert   Group ID
+<CUSTOM>       uid </CUSTOM>       # set customer User  ID
+<CUSTOM_GROUP> gid </CUSTOM_GROUP> # set customer Group ID
+
+<USER0>        uid </USER0>        # set user 0   User  ID
+<USER1>        uid </USER1>        # set user 1   User  ID
+<USER2>        uid </USER2>        # set user 2   User  ID
+<USER3>        uid </USER3>        # set user 3   User  ID
+<USER4>        uid </USER4>        # set user 4   User  ID
+<USER5>        uid </USER5>        # set user 5   User  ID
+<USER6>        uid </USER6>        # set user 6   User  ID
+<USER7>        uid </USER7>        # set user 7   User  ID
+<USER8>        uid </USER8>        # set user 8   User  ID
+<USER9>        uid </USER9>        # set user 9   User  ID
+<USER10>       uid </USER10>       # set user 10  User  ID
+<USER11>       uid </USER11>       # set user 11  User  ID
+<USER12>       uid </USER12>       # set user 12  User  ID
+<USER13>       uid </USER13>       # set user 13  User  ID
+<USER14>       uid </USER14>       # set user 14  User  ID
+<USER15>       uid </USER15>       # set user 15  User  ID
+
+<LIST>
+<ALL> mask </ALL>
+<PERM><NAME> name </NAME><MASK> mask </MASK></PERM>
+<PERM><NAME> name </NAME><MASK> mask </MASK></PERM>
+</LIST>
+</AUTH>
+)");
+
+    REQUIRE(tree["OPER"].as<std::string>() == "uid");
+    REQUIRE(tree["OPER_GROUP"].as<std::string>() == "gid");
+    // Other user/group IDs omitted for brevity
+
+    REQUIRE(tree["LIST"]["PERM"].is_array());
+    REQUIRE(tree["LIST"]["PERM"].size() == 2);
+    REQUIRE(tree["LIST"]["PERM"][0]["NAME"].as<std::string>() == "name");
+    REQUIRE(tree["LIST"]["PERM"][0]["MASK"].as<std::string>() == "mask");
+    // Second PERM omitted for brevity
+}

--- a/tests/data_processors/test_xml_processor.cc
+++ b/tests/data_processors/test_xml_processor.cc
@@ -1,8 +1,8 @@
 /**
- * \file   test_XmlDataProcessor.cc
+ * \file   test_xml_processor.cc
  * \author Jan Behrens
  * \date   Created on November 19, 2025
- * \brief  Test suite for the XmlDataProcessor class.
+ * \brief  Test suite for the XmlProcessor class.
  *
  * \copyright Copyright 2019-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
@@ -30,7 +30,7 @@ using gul17::DataTree;
 using gul17::from_xml_string;
 using gul17::to_xml_string;
 
-TEST_CASE("XmlDataProcessor: XML parsing", "[XmlDataProcessor]")
+TEST_CASE("XmlProcessor: XML parsing", "[XmlProcessor]")
 {
     auto tree = from_xml_string(
 R"(<root>
@@ -67,7 +67,7 @@ R"(<root>
     REQUIRE(tree["invalid"].is_empty());
 }
 
-TEST_CASE("XmlDataProcessor: XML parsing with attributes and comments", "[XmlDataProcessor]")
+TEST_CASE("XmlProcessor: XML parsing with attributes and comments", "[XmlProcessor]")
 {
     auto tree = from_xml_string(
 R"(<root>
@@ -100,7 +100,7 @@ R"(<root>
     REQUIRE(tree["#text"][2].as<std::string>() == "TEXT CONTENT 3");
 }
 
-TEST_CASE("XmlDataProcessor: XML parsing with escape sequences", "[XmlDataProcessor]")
+TEST_CASE("XmlProcessor: XML parsing with escape sequences", "[XmlProcessor]")
 {
     auto tree = from_xml_string(
 R"(
@@ -113,7 +113,7 @@ R"(
     REQUIRE(tree["key1"].as<std::string>() == "><&\"'");
 }
 
-TEST_CASE("XmlDataProcessor: XML parsing with errors", "[XmlDataProcessor]")
+TEST_CASE("XmlProcessor: XML parsing with errors", "[XmlProcessor]")
 {
     REQUIRE_THROWS(from_xml_string(R"(<root><key1></root>)")); // Missing closing tag
     REQUIRE_THROWS(from_xml_string(R"(<root><key1></key2></root>)")); // Mismatched closing tag
@@ -121,7 +121,7 @@ TEST_CASE("XmlDataProcessor: XML parsing with errors", "[XmlDataProcessor]")
     REQUIRE_THROWS(from_xml_string(R"(<root><key1 attr1="1" attr1="2"/></root>)")); // Duplicate attribute
 }
 
-TEST_CASE("XmlDataProcessor: XML serialization", "[XmlDataProcessor]")
+TEST_CASE("XmlProcessor: XML serialization", "[XmlProcessor]")
 {
     auto tree = DataTree::make_object();
 
@@ -149,7 +149,7 @@ R"(<root>
     REQUIRE(xml_str == expected_xml);
 }
 
-TEST_CASE("XmlDataProcessor: XML serialization with attributes", "[XmlDataProcessor]")
+TEST_CASE("XmlProcessor: XML serialization with attributes", "[XmlProcessor]")
 {
     auto tree = DataTree::make_object();
 
@@ -176,7 +176,7 @@ R"(<root>
     REQUIRE(xml_str == expected_xml);
 }
 
-TEST_CASE("XmlDataProcessor: XML parsing of SVR.AUTH string", "[XmlDataProcessor]")
+TEST_CASE("XmlProcessor: XML parsing of SVR.AUTH string", "[XmlProcessor]")
 {
     auto tree = from_xml_string(
 R"(

--- a/tests/data_processors/test_yaml_processor.cc
+++ b/tests/data_processors/test_yaml_processor.cc
@@ -1,0 +1,134 @@
+/**
+ * \file   test_YamlDataProcessor.cc
+ * \author Jan Behrens
+ * \date   Created on November 20, 2025
+ * \brief  Test suite for the YamlDataProcessor class.
+ *
+ * \copyright Copyright 2019-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, either version 2.1 of the license, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#include "gul17/data_processors.h"
+
+#include <catch2/catch_template_test_macros.hpp>
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+using gul17::DataTree;
+using gul17::from_yaml_string;
+using gul17::to_yaml_string;
+
+TEST_CASE("YamlDataProcessor: YAML parsing", "[YamlDataProcessor]")
+{
+    auto tree = from_yaml_string(
+R"(
+key1: value1
+key2: 42
+key3:
+  - 1
+  - 2
+  - 3
+key4:
+  nestedKey: 3.1415
+key5: null
+)");
+
+    REQUIRE(tree["key1"].is_string());
+    REQUIRE(tree["key1"].as<std::string>() == "value1");
+
+    REQUIRE(tree["key2"].is_number());
+    REQUIRE(tree["key2"].as<int>() == 42);
+
+    REQUIRE(tree["key3"].is_array());
+    REQUIRE(tree["key3"].size() == 3);
+    REQUIRE(tree["key3"][0].as<int>() == 1);
+    REQUIRE(tree["key3"][1].as<int>() == 2);
+    REQUIRE(tree["key3"][2].as<int>() == 3);
+
+    REQUIRE(tree["key4"].is_object());
+    REQUIRE(tree["key4"]["nestedKey"].is_double());
+    REQUIRE(tree["key4"]["nestedKey"].as<double>() == Catch::Approx(3.1415));
+
+    REQUIRE(tree["key5"].is_null());
+
+    REQUIRE(tree.has_key("invalid") == false);
+    REQUIRE(tree["invalid"].is_empty());
+}
+
+TEST_CASE("YamlDataProcessor: YAML parsing with comments", "[YamlDataProcessor]")
+{
+    auto tree = from_yaml_string(
+R"(
+# ignored comment
+key1: value1
+key2: 42 # another comment
+)");
+
+    REQUIRE(tree["key1"].is_string());
+    REQUIRE(tree["key1"].as<std::string>() == "value1");
+
+    REQUIRE(tree["key2"].is_number());
+    REQUIRE(tree["key2"].as<int>() == 42);
+}
+
+TEST_CASE("YamlDataProcessor: YAML parsing with escape sequences", "[YamlDataProcessor]")
+{
+    auto tree = from_yaml_string(
+R"(
+key1: "\nvalue1\t"
+key2: "\"value\\2\""
+key3: "\u0032\u0034"
+)");
+
+    REQUIRE(tree["key1"].is_string());
+    REQUIRE(tree["key1"].as<std::string>() == "\nvalue1\t");
+
+    REQUIRE(tree["key2"].is_string());
+    REQUIRE(tree["key2"].as<std::string>() == "\"value\\2\"");
+
+    REQUIRE(tree["key3"].is_string());
+    REQUIRE(tree["key3"].as<std::string>() == " \"");
+}
+
+TEST_CASE("YamlDataProcessor: YAML parsing with errors", "[YamlDataProcessor]")
+{
+    // Currently, the parser does not throw exceptions for malformed YAML.
+}
+
+TEST_CASE("YamlDataProcessor: YAML serialization", "[YamlDataProcessor]")
+{
+    auto tree = DataTree::make_object();
+
+    tree["key1"] = "value1";
+    tree["key2"] = 42;
+    tree["key3"] = DataTree::Array{1, 2, 3};
+    tree["key4"] = DataTree::Object{{"nestedKey", 3.1415}};
+    tree["key5"] = nullptr;
+
+    std::string expected_yaml =
+R"(key1: value1
+key2: 42
+key3:
+  - 1
+  - 2
+  - 3
+key4:
+  nestedKey: 3.1415
+key5: null
+)";
+
+    auto yaml_str = to_yaml_string(tree, 2);
+    REQUIRE(yaml_str == expected_yaml);
+}

--- a/tests/data_processors/test_yaml_processor.cc
+++ b/tests/data_processors/test_yaml_processor.cc
@@ -26,6 +26,8 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 
+#if 0 // Temporarily disable all tests to focus on test_func()
+
 using gul17::DataTree;
 using gul17::from_yaml_string;
 using gul17::to_yaml_string;
@@ -132,3 +134,5 @@ key5: null
     auto yaml_str = to_yaml_string(tree, 2);
     REQUIRE(yaml_str == expected_yaml);
 }
+
+#endif

--- a/tests/data_processors/test_yaml_processor.cc
+++ b/tests/data_processors/test_yaml_processor.cc
@@ -1,8 +1,8 @@
 /**
- * \file   test_YamlDataProcessor.cc
+ * \file   test_yaml_processor.cc
  * \author Jan Behrens
  * \date   Created on November 20, 2025
- * \brief  Test suite for the YamlDataProcessor class.
+ * \brief  Test suite for the YamlProcessor class.
  *
  * \copyright Copyright 2019-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
@@ -30,7 +30,7 @@ using gul17::DataTree;
 using gul17::from_yaml_string;
 using gul17::to_yaml_string;
 
-TEST_CASE("YamlDataProcessor: YAML parsing", "[YamlDataProcessor]")
+TEST_CASE("YamlProcessor: YAML parsing", "[YamlProcessor]")
 {
     auto tree = from_yaml_string(
 R"(
@@ -67,7 +67,7 @@ key5: null
     REQUIRE(tree["invalid"].is_empty());
 }
 
-TEST_CASE("YamlDataProcessor: YAML parsing with comments", "[YamlDataProcessor]")
+TEST_CASE("YamlProcessor: YAML parsing with comments", "[YamlProcessor]")
 {
     auto tree = from_yaml_string(
 R"(
@@ -83,7 +83,7 @@ key2: 42 # another comment
     REQUIRE(tree["key2"].as<int>() == 42);
 }
 
-TEST_CASE("YamlDataProcessor: YAML parsing with escape sequences", "[YamlDataProcessor]")
+TEST_CASE("YamlProcessor: YAML parsing with escape sequences", "[YamlProcessor]")
 {
     auto tree = from_yaml_string(
 R"(
@@ -102,12 +102,12 @@ key3: "\u0032\u0034"
     REQUIRE(tree["key3"].as<std::string>() == "24");
 }
 
-TEST_CASE("YamlDataProcessor: YAML parsing with errors", "[YamlDataProcessor]")
+TEST_CASE("YamlProcessor: YAML parsing with errors", "[YamlProcessor]")
 {
     // Currently, the parser does not throw exceptions for malformed YAML.
 }
 
-TEST_CASE("YamlDataProcessor: YAML serialization", "[YamlDataProcessor]")
+TEST_CASE("YamlProcessor: YAML serialization", "[YamlProcessor]")
 {
     auto tree = DataTree::make_object();
 

--- a/tests/data_processors/test_yaml_processor.cc
+++ b/tests/data_processors/test_yaml_processor.cc
@@ -99,7 +99,7 @@ key3: "\u0032\u0034"
     REQUIRE(tree["key2"].as<std::string>() == "\"value\\2\"");
 
     REQUIRE(tree["key3"].is_string());
-    REQUIRE(tree["key3"].as<std::string>() == " \"");
+    REQUIRE(tree["key3"].as<std::string>() == "24");
 }
 
 TEST_CASE("YamlDataProcessor: YAML parsing with errors", "[YamlDataProcessor]")

--- a/tests/data_processors/test_yaml_processor.cc
+++ b/tests/data_processors/test_yaml_processor.cc
@@ -26,8 +26,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_approx.hpp>
 
-#if 0 // Temporarily disable all tests to focus on test_func()
-
 using gul17::DataTree;
 using gul17::from_yaml_string;
 using gul17::to_yaml_string;
@@ -134,5 +132,3 @@ key5: null
     auto yaml_str = to_yaml_string(tree, 2);
     REQUIRE(yaml_str == expected_yaml);
 }
-
-#endif

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -44,6 +44,9 @@ tests = [
     'test_Trigger.cc',
     'test_trim.cc',
     'test_type_name.cc',
+    'data_processors/test_json_processor.cc',
+    'data_processors/test_xml_processor.cc',
+    'data_processors/test_yaml_processor.cc',
 ]
 
 test('all',


### PR DESCRIPTION
This PR adds parsing and serialization features for structured data in JSON, YAML and XML formats.

For each format, a new function `to_*_string()` and `from_*_string()` is exposed in the gul17 library via the `data_processors.h` header. These functions convert between the string representation of the data and the new `DataTree` structure, which contains the corresponding tree nodes.

The `DataTree` struct is essentially a wrapper around an `std::variant` value that can hold null, boolean, integer, float and string values as well as other `DataTree` objects in the form of a map or vector. This allows to represent each data item by a node in the tree, and includes sub-trees and node arrays.

The XML parser/serializer also handles attributes and multiple elements of the same name. Attributes are added as tree nodes with a name like `"@attr"` under the current XML element, and multiple elements that have the same XML tag on the same tree level are added as a node array. This is not a full-scale DOM/SAX-style parser of course, so there are some limitations.

Unit tests for the 3 formats are provided as well.

I think this enhancement would be useful to other projects such as the DOOCS serverlib/clientlib where XML is already being used; and JSON/YAML parsing would add a new and convenient way of transferring structured data via the DOOCS protocol or to read and write configuration files, etc.