### PR TITLE
Address clang signed-unsigned warnings

### DIFF
--- a/include/gul17/string_util.h
+++ b/include/gul17/string_util.h
@@ -151,12 +151,14 @@ template <typename Iterator>
 inline std::string
 hex_string(Iterator begin, Iterator end, std::string_view separator = "")
 {
-    const std::size_t n = std::distance(begin, end);
+    const auto range_length = std::distance(begin, end);
 
     std::string result;
 
-    if (n > 0)
+    if (range_length > 0)
     {
+        const auto n = static_cast<std::size_t>(range_length);
+
         result.reserve(2 * sizeof(*begin) * n + separator.size() * (n - 1));
 
         result += hex_string(*begin);

--- a/src/string_util.cc
+++ b/src/string_util.cc
@@ -4,7 +4,7 @@
  * \authors \ref contributors
  * \date    Created on 31 August 2018
  *
- * \copyright Copyright 2018-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2018-2026 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -88,7 +88,7 @@ std::string_view safe_string_view(const char* char_ptr, std::size_t length)
 
     auto end_ptr = std::find(char_ptr, char_ptr + length, '\0');
 
-    return std::string_view(char_ptr, end_ptr - char_ptr);
+    return std::string_view(char_ptr, static_cast<std::size_t>(end_ptr - char_ptr));
 }
 
 } // namespace gul17

--- a/tests/test_escape.cc
+++ b/tests/test_escape.cc
@@ -4,7 +4,7 @@
  * \date   Created on August 31, 2018
  * \brief  Part of test suite for string utility functions in the General Utility Library.
  *
- * \copyright Copyright 2018-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2018-2026 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -63,7 +63,7 @@ TEST_CASE("Check escaping and unescaping with random strings", "[escape]")
     std::default_random_engine re(r());
     std::uniform_int_distribution<unsigned short> uniform_dist(0, 255);
 
-    for (int len = 0; len < 100; len++)
+    for (std::size_t len = 0; len < 100u; ++len)
     {
         std::string original(len, ' ');
 


### PR DESCRIPTION
This MR fixes a few warnings generated by clang 18 about implicit conversions between signed and unsigned values. The changes are straightforward (I hope).