### PR TITLE
Do not use std::aligned_storage

### DIFF
--- a/data/doxygen.h
+++ b/data/doxygen.h
@@ -4,7 +4,7 @@
  * \date    Created on August 24, 2018
  * \brief   Doxygen input file for the General Utility Library.
  *
- * \copyright Copyright 2018-2025 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2018-2026 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -145,6 +145,11 @@ namespace gul17 {
  * versioning.
  *
  * \section changelog_gul17 GUL17 Versions
+ *
+ * \subsection V26_X_X Unreleased
+ *
+ * - Avoid using std::result_of_t which is removed in C++20.
+ * - Avoid using std::aligned_storage which is deprecated in C++23.
  *
  * \subsection V26_2_0 Version 26.2.0
  *

--- a/include/gul17/SmallVector.h
+++ b/include/gul17/SmallVector.h
@@ -34,6 +34,7 @@
 #include <new>
 #include <stdexcept>
 #include <type_traits>
+#include <utility>
 
 #include "gul17/cat.h"
 #include "gul17/finalizer.h"
@@ -1532,14 +1533,9 @@ private:
         // Can we simply steal the complete allocated storage?
         if (other.is_storage_allocated())
         {
-            data_ptr_ = other.data_ptr_;
-            other.data_ptr_ = other.get_internal_array_pointer();
-
-            capacity_ = other.capacity_;
-            other.capacity_ = other.inner_capacity();
-
-            size_ = other.size_;
-            other.size_ = 0u;
+            data_ptr_ = std::exchange(other.data_ptr_, other.get_internal_array_pointer());
+            capacity_ = std::exchange(other.capacity_, other.inner_capacity());
+            size_ = std::exchange(other.size_, 0u);
         }
         else // otherwise fall back to moving (or at least copying) all elements
         {
@@ -1574,8 +1570,7 @@ private:
         uninitialized_move_or_copy(b.begin(), b.end(), a.get_internal_array_pointer());
         destroy_range(b.begin(), b.end());
 
-        b.data_ptr_ = a.data_ptr_;
-        a.data_ptr_ = a.get_internal_array_pointer();
+        b.data_ptr_ = std::exchange(a.data_ptr_, a.get_internal_array_pointer());
 
         std::swap(a.capacity_, b.capacity_);
         std::swap(a.size_, b.size_);

--- a/include/gul17/SmallVector.h
+++ b/include/gul17/SmallVector.h
@@ -425,7 +425,8 @@ public:
     ~SmallVector()
     {
         clear();
-        deallocate_storage();
+        if (is_storage_allocated())
+            deallocate_space_for_elements(data_ptr_);
     }
 
     /**
@@ -940,7 +941,8 @@ public:
         if (&other != this)
         {
             clear();
-            deallocate_storage();
+            if (is_storage_allocated())
+                deallocate_space_for_elements(data_ptr_);
             move_or_copy_all_elements_from(std::move(other));
         }
 
@@ -1083,7 +1085,9 @@ public:
         uninitialized_move_or_copy(data(), d_end, reinterpret_cast<ValueType*>(new_data));
         destroy_range(data(), d_end);
 
-        deallocate_storage();
+        if (is_storage_allocated())
+            deallocate_space_for_elements(data_ptr_);
+
         data_ptr_ = new_data;
         new_data = nullptr;
         capacity_ = new_capacity;
@@ -1179,7 +1183,9 @@ public:
         uninitialized_move_or_copy(data(), d_end, reinterpret_cast<ValueType*>(new_data));
         destroy_range(data(), d_end);
 
-        deallocate_storage();
+        if (is_storage_allocated())
+            deallocate_space_for_elements(data_ptr_);
+
         if (allocation)
         {
             data_ptr_ = allocation;
@@ -1315,20 +1321,6 @@ private:
     static void deallocate_space_for_elements(std::byte* ptr) noexcept
     {
         ::operator delete[](ptr, alignment);
-    }
-
-    /**
-     * Deallocate the data buffer if it is allocated on the heap.
-     * If that was the case, data_ptr_ is null after this call and must be reassigned to
-     * re-establish the class invariants.
-     */
-    void deallocate_storage() noexcept
-    {
-        if (!is_storage_allocated())
-            return;
-
-        deallocate_space_for_elements(data_ptr_);
-        data_ptr_ = nullptr;
     }
 
     /**

--- a/include/gul17/SmallVector.h
+++ b/include/gul17/SmallVector.h
@@ -1076,8 +1076,8 @@ public:
             return;
 
         // Allocate aligned memory for the new "outer" capacity.
-        auto* new_data = new (alignment) std::byte[new_capacity * sizeof(ValueType)];
-        auto _ = finally([&new_data]() { ::operator delete[](new_data, alignment); });
+        auto* new_data = allocate_space_for_elements(new_capacity);
+        auto _ = finally([&new_data]() { deallocate_space_for_elements(new_data); });
 
         auto* d_end = data_end();
         uninitialized_move_or_copy(data(), d_end, reinterpret_cast<ValueType*>(new_data));
@@ -1163,7 +1163,7 @@ public:
 
         std::byte* new_data{};
         std::byte* allocation{};
-        auto _ = finally([&allocation]() { ::operator delete[](allocation, alignment); });
+        auto _ = finally([&allocation]() { deallocate_space_for_elements(allocation); });
 
         if (new_capacity == inner_capacity())
         {
@@ -1171,7 +1171,7 @@ public:
         }
         else
         {
-            allocation = new (alignment) std::byte[new_capacity * sizeof(ValueType)];
+            allocation = allocate_space_for_elements(new_capacity);
             new_data = allocation;
         }
 
@@ -1240,6 +1240,16 @@ private:
     SizeType size_{ 0u };
 
     /**
+     * Allocate aligned, uninitialized memory for storing a certain number of elements.
+     * The memory has to be deallocated with deallocate_space_for_elements() after use.
+     */
+    static std::byte* allocate_space_for_elements(std::size_t num_elements)
+    {
+        return static_cast<std::byte*>(
+            ::operator new[](num_elements * sizeof(ValueType), alignment));
+    }
+
+    /**
      * Copy a range of values into uninitialized cells.
      *
      * If the element copy constructor throws an exception, all elements copied until this
@@ -1301,6 +1311,12 @@ private:
         return reinterpret_cast<const ValueType*>(data_ptr_) + size_;
     }
 
+    /// Deallocate aligned memory that was reserved with allocate_space_for_elements().
+    static void deallocate_space_for_elements(std::byte* ptr) noexcept
+    {
+        ::operator delete[](ptr, alignment);
+    }
+
     /**
      * Deallocate the data buffer if it is allocated on the heap.
      * If that was the case, data_ptr_ is null after this call and must be reassigned to
@@ -1311,7 +1327,7 @@ private:
         if (!is_storage_allocated())
             return;
 
-        ::operator delete[](data_ptr_, alignment);
+        deallocate_space_for_elements(data_ptr_);
         data_ptr_ = nullptr;
     }
 

--- a/include/gul17/SmallVector.h
+++ b/include/gul17/SmallVector.h
@@ -603,7 +603,7 @@ public:
      */
     constexpr ValueType* data() noexcept
     {
-        return reinterpret_cast<ValueType*>(data_ptr_);
+        return data_ptr_;
     }
 
     /**
@@ -612,7 +612,7 @@ public:
      */
     constexpr const ValueType* data() const noexcept
     {
-        return reinterpret_cast<const ValueType*>(data_ptr_);
+        return data_ptr_;
     }
 
     /**
@@ -1082,7 +1082,7 @@ public:
         auto _ = finally([&new_data]() { deallocate_space_for_elements(new_data); });
 
         auto* d_end = data_end();
-        uninitialized_move_or_copy(data(), d_end, reinterpret_cast<ValueType*>(new_data));
+        uninitialized_move_or_copy(data(), d_end, new_data);
         destroy_range(data(), d_end);
 
         if (is_storage_allocated())
@@ -1165,13 +1165,13 @@ public:
         if (new_capacity == capacity_)
             return;
 
-        std::byte* new_data{};
-        std::byte* allocation{};
+        ValueType* new_data{};
+        ValueType* allocation{};
         auto _ = finally([&allocation]() { deallocate_space_for_elements(allocation); });
 
         if (new_capacity == inner_capacity())
         {
-            new_data = internal_array_.data();
+            new_data = get_internal_array_pointer();
         }
         else
         {
@@ -1180,7 +1180,7 @@ public:
         }
 
         auto* d_end = data_end();
-        uninitialized_move_or_copy(data(), d_end, reinterpret_cast<ValueType*>(new_data));
+        uninitialized_move_or_copy(data(), d_end, new_data);
         destroy_range(data(), d_end);
 
         if (is_storage_allocated())
@@ -1228,7 +1228,7 @@ private:
     std::array<std::byte, in_capacity * sizeof(ValueType)> internal_array_;
 
     /// Pointer to internal or external contiguous data storage.
-    std::byte* data_ptr_{ internal_array_.data() };
+    ValueType* data_ptr_{ get_internal_array_pointer() };
 
     /// Capacity of the vector (i.e. number of elements that can be stored without
     /// enlarging the container)
@@ -1240,9 +1240,9 @@ private:
      * Allocate aligned, uninitialized memory for storing a certain number of elements.
      * The memory has to be deallocated with deallocate_space_for_elements() after use.
      */
-    static std::byte* allocate_space_for_elements(std::size_t num_elements)
+    static ValueType* allocate_space_for_elements(std::size_t num_elements)
     {
-        return static_cast<std::byte*>(
+        return static_cast<ValueType*>(
             ::operator new[](num_elements * sizeof(ValueType),
                              std::align_val_t{ alignof(ValueType) }));
     }
@@ -1297,20 +1297,20 @@ private:
             ::new(static_cast<void*>(p)) ValueType(value);
     }
 
-    /// Return a non-dereferencable pointer past the last element.
+    /// Return a non-dereferenceable pointer past the last element.
     constexpr ValueType* data_end() noexcept
     {
-        return reinterpret_cast<ValueType*>(data_ptr_) + size_;
+        return data_ptr_ + size_;
     }
 
-    /// Return a non-dereferencable pointer past the last element.
+    /// Return a non-dereferenceable pointer past the last element.
     constexpr const ValueType* data_end() const noexcept
     {
-        return reinterpret_cast<const ValueType*>(data_ptr_) + size_;
+        return data_ptr_ + size_;
     }
 
     /// Deallocate aligned memory that was reserved with allocate_space_for_elements().
-    static void deallocate_space_for_elements(std::byte* ptr) noexcept
+    static void deallocate_space_for_elements(ValueType* ptr) noexcept
     {
         ::operator delete[](ptr, std::align_val_t{ alignof(ValueType) });
     }
@@ -1395,6 +1395,18 @@ private:
         }
     }
 
+    /// Return a ValueType pointer to the internal array storage.
+    const ValueType* get_internal_array_pointer() const noexcept
+    {
+        return reinterpret_cast<const ValueType*>(internal_array_.data());
+    }
+
+    /// Return a ValueType pointer to the internal array storage.
+    ValueType* get_internal_array_pointer() noexcept
+    {
+        return reinterpret_cast<ValueType*>(internal_array_.data());
+    }
+
     /**
      * Increase the capacity of the vector, typically by ~50%.
      *
@@ -1453,7 +1465,7 @@ private:
     /// Determine if this vector is using allocated external storage.
     bool is_storage_allocated() const noexcept
     {
-        return data_ptr_ != internal_array_.data();
+        return data_ptr_ != get_internal_array_pointer();
     }
 
     /**
@@ -1520,13 +1532,18 @@ private:
         // Can we simply steal the complete allocated storage?
         if (other.is_storage_allocated())
         {
-            data_ptr_ = other.data_ptr_;    other.data_ptr_ = other.internal_array_.data();
-            capacity_ = other.capacity_;    other.capacity_ = other.inner_capacity();
-            size_ = other.size_;            other.size_ = 0u;
+            data_ptr_ = other.data_ptr_;
+            other.data_ptr_ = other.get_internal_array_pointer();
+
+            capacity_ = other.capacity_;
+            other.capacity_ = other.inner_capacity();
+
+            size_ = other.size_;
+            other.size_ = 0u;
         }
         else // otherwise fall back to moving (or at least copying) all elements
         {
-            data_ptr_ = internal_array_.data();
+            data_ptr_ = get_internal_array_pointer();
             capacity_ = in_capacity;
             uninitialized_move_or_copy(other.begin(), other.end(), data());
             size_ = other.size();
@@ -1554,12 +1571,11 @@ private:
      */
     static void swap_heap_with_internal(SmallVector &a, SmallVector &b)
     {
-        uninitialized_move_or_copy(b.begin(), b.end(),
-            reinterpret_cast<ValueType*>(a.internal_array_.data()));
+        uninitialized_move_or_copy(b.begin(), b.end(), a.get_internal_array_pointer());
         destroy_range(b.begin(), b.end());
 
         b.data_ptr_ = a.data_ptr_;
-        a.data_ptr_ = a.internal_array_.data();
+        a.data_ptr_ = a.get_internal_array_pointer();
 
         std::swap(a.capacity_, b.capacity_);
         std::swap(a.size_, b.size_);

--- a/include/gul17/SmallVector.h
+++ b/include/gul17/SmallVector.h
@@ -1303,7 +1303,8 @@ private:
 
     /**
      * Deallocate the data buffer if it is allocated on the heap.
-     * If that was the case, data_ptr_ dangles after this call.
+     * If that was the case, data_ptr_ is null after this call and must be reassigned to
+     * re-establish the class invariants.
      */
     void deallocate_storage() noexcept
     {
@@ -1311,6 +1312,7 @@ private:
             return;
 
         ::operator delete[](data_ptr_, alignment);
+        data_ptr_ = nullptr;
     }
 
     /**
@@ -1509,6 +1511,8 @@ private:
      * performs no check for self-assignment.
      *
      * \pre `size() == 0 and is_allocated() == false and &other != this`
+     * \post `data_ptr_ != nullptr` (it either points to the allocated storage stolen from
+     *       `other` or to the internal array)
      */
     void move_or_copy_all_elements_from(SmallVector&& other)
         noexcept(std::is_nothrow_move_constructible<ValueType>::value)

--- a/include/gul17/SmallVector.h
+++ b/include/gul17/SmallVector.h
@@ -1186,16 +1186,9 @@ public:
         if (is_storage_allocated())
             deallocate_space_for_elements(data_ptr_);
 
-        if (allocation)
-        {
-            data_ptr_ = allocation;
-            allocation = nullptr;
-        }
-        else
-        {
-            data_ptr_ = new_data;
-        }
+        data_ptr_ = new_data;
         capacity_ = new_capacity;
+        allocation = nullptr; // Avoid deallocation by the "finally" guard
     }
 
     /// Return the number of elements that are currently stored.

--- a/include/gul17/SmallVector.h
+++ b/include/gul17/SmallVector.h
@@ -4,7 +4,7 @@
  * \date    Created on August 17, 2020
  * \brief   Definition of the SmallVector class template.
  *
- * \copyright Copyright 2020-2023 Deutsches Elektronen-Synchrotron (DESY), Hamburg
+ * \copyright Copyright 2020-2026 Deutsches Elektronen-Synchrotron (DESY), Hamburg
  *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published
@@ -25,16 +25,19 @@
 
 #include <algorithm>
 #include <array>
+#include <cstddef>
 #include <cstdint>
 #include <initializer_list>
 #include <iterator>
 #include <limits>
 #include <memory>
+#include <new>
 #include <stdexcept>
 #include <type_traits>
 
-#include "gul17/internal.h"
 #include "gul17/cat.h"
+#include "gul17/finalizer.h"
+#include "gul17/internal.h"
 
 namespace gul17 {
 
@@ -422,9 +425,7 @@ public:
     ~SmallVector()
     {
         clear();
-
-        if (is_storage_allocated())
-            delete[] data_ptr_;
+        deallocate_storage();
     }
 
     /**
@@ -939,8 +940,7 @@ public:
         if (&other != this)
         {
             clear();
-            if (is_storage_allocated())
-                delete[] data_ptr_;
+            deallocate_storage();
             move_or_copy_all_elements_from(std::move(other));
         }
 
@@ -1075,17 +1075,17 @@ public:
         if (new_capacity <= capacity_)
             return;
 
-        auto new_data = std::make_unique<AlignedStorage[]>(new_capacity);
+        // Allocate aligned memory for the new "outer" capacity.
+        auto* new_data = new (alignment) std::byte[new_capacity * sizeof(ValueType)];
+        auto _ = finally([&new_data]() { ::operator delete[](new_data, alignment); });
 
-        const auto d_end = data_end();
-
-        uninitialized_move_or_copy(data(), d_end, reinterpret_cast<ValueType*>(new_data.get()));
+        auto* d_end = data_end();
+        uninitialized_move_or_copy(data(), d_end, reinterpret_cast<ValueType*>(new_data));
         destroy_range(data(), d_end);
 
-        if (is_storage_allocated())
-            delete[] data_ptr_;
-
-        data_ptr_ = new_data.release();
+        deallocate_storage();
+        data_ptr_ = new_data;
+        new_data = nullptr;
         capacity_ = new_capacity;
     }
 
@@ -1161,25 +1161,34 @@ public:
         if (new_capacity == capacity_)
             return;
 
-        AlignedStorage* new_data;
-        auto new_memory = std::unique_ptr<AlignedStorage[]>{};
+        std::byte* new_data{};
+        std::byte* allocation{};
+        auto _ = finally([&allocation]() { ::operator delete[](allocation, alignment); });
 
-        if (new_capacity == inner_capacity()) {
+        if (new_capacity == inner_capacity())
+        {
             new_data = internal_array_.data();
-        } else {
-            new_memory = std::make_unique<AlignedStorage[]>(new_capacity);
-            new_data = new_memory.get();
+        }
+        else
+        {
+            allocation = new (alignment) std::byte[new_capacity * sizeof(ValueType)];
+            new_data = allocation;
         }
 
-        const auto d_end = data_end();
-
+        auto* d_end = data_end();
         uninitialized_move_or_copy(data(), d_end, reinterpret_cast<ValueType*>(new_data));
         destroy_range(data(), d_end);
 
-        if (is_storage_allocated())
-            delete[] data_ptr_;
-
-        data_ptr_ = new_memory ? new_memory.release() : new_data;
+        deallocate_storage();
+        if (allocation)
+        {
+            data_ptr_ = allocation;
+            allocation = nullptr;
+        }
+        else
+        {
+            data_ptr_ = new_data;
+        }
         capacity_ = new_capacity;
     }
 
@@ -1212,17 +1221,17 @@ public:
     }
 
 private:
-    using AlignedStorage =
-        typename std::aligned_storage<sizeof(ValueType), alignof(ValueType)>::type;
+    static constexpr std::align_val_t alignment{ alignof(ValueType) };
 
     /**
-     * This union either holds the storage for the "internal" elements or, if the vector
-     * has grown beyond that size, a pointer to storage on the heap.
+     * Uninitialized storage for the internal elements (used only if size() <=
+     * inner_capacity()).
      */
-    std::array<AlignedStorage, in_capacity> internal_array_;
+    alignas(ValueType)
+    std::array<std::byte, in_capacity * sizeof(ValueType)> internal_array_;
 
     /// Pointer to internal or external contiguous data storage.
-    AlignedStorage* data_ptr_{ internal_array_.data() };
+    std::byte* data_ptr_{ internal_array_.data() };
 
     /// Capacity of the vector (i.e. number of elements that can be stored without
     /// enlarging the container)
@@ -1290,6 +1299,18 @@ private:
     constexpr const ValueType* data_end() const noexcept
     {
         return reinterpret_cast<const ValueType*>(data_ptr_) + size_;
+    }
+
+    /**
+     * Deallocate the data buffer if it is allocated on the heap.
+     * If that was the case, data_ptr_ dangles after this call.
+     */
+    void deallocate_storage() noexcept
+    {
+        if (!is_storage_allocated())
+            return;
+
+        ::operator delete[](data_ptr_, alignment);
     }
 
     /**

--- a/include/gul17/SmallVector.h
+++ b/include/gul17/SmallVector.h
@@ -1220,8 +1220,6 @@ public:
     }
 
 private:
-    static constexpr std::align_val_t alignment{ alignof(ValueType) };
-
     /**
      * Uninitialized storage for the internal elements (used only if size() <=
      * inner_capacity()).
@@ -1245,7 +1243,8 @@ private:
     static std::byte* allocate_space_for_elements(std::size_t num_elements)
     {
         return static_cast<std::byte*>(
-            ::operator new[](num_elements * sizeof(ValueType), alignment));
+            ::operator new[](num_elements * sizeof(ValueType),
+                             std::align_val_t{ alignof(ValueType) }));
     }
 
     /**
@@ -1313,7 +1312,7 @@ private:
     /// Deallocate aligned memory that was reserved with allocate_space_for_elements().
     static void deallocate_space_for_elements(std::byte* ptr) noexcept
     {
-        ::operator delete[](ptr, alignment);
+        ::operator delete[](ptr, std::align_val_t{ alignof(ValueType) });
     }
 
     /**

--- a/tests/test_SmallVector.cc
+++ b/tests/test_SmallVector.cc
@@ -575,6 +575,68 @@ TEMPLATE_TEST_CASE("SmallVector: Iterator traits", "[SmallVector]",
         >::value == true);
 }
 
+namespace {
+
+struct OverAligned
+{
+    alignas(1024) char data[64];
+};
+
+template <typename VectorT>
+std::pair<std::uintptr_t, std::uintptr_t> get_front_and_back_pointers(VectorT& vec)
+{
+    if (vec.empty())
+        throw std::logic_error("Vector is empty");
+
+    return { reinterpret_cast<std::uintptr_t>(&vec.front()),
+             reinterpret_cast<std::uintptr_t>(&vec.back()) };
+}
+
+template <typename VectorT>
+void test_alignment_with()
+{
+    VectorT vec;
+    using ValueT = typename VectorT::ValueType;
+
+    CAPTURE(vec.inner_capacity());
+    CAPTURE(alignof(ValueT));
+
+    for (unsigned int i = 1u; i <= 50; ++i)
+    {
+        vec.push_back(ValueT{});
+        CAPTURE(vec.size());
+
+        auto [front_ptr, back_ptr] = get_front_and_back_pointers(vec);
+        REQUIRE(front_ptr % alignof(ValueT) == 0);
+        REQUIRE(back_ptr % alignof(ValueT) == 0);
+        REQUIRE(back_ptr - front_ptr == sizeof(ValueT) * (vec.size() - 1u));
+    }
+
+    while (vec.size() > 1u)
+    {
+        vec.pop_back();
+        vec.shrink_to_fit();
+        CAPTURE(vec.size());
+
+        auto [front_ptr, back_ptr] = get_front_and_back_pointers(vec);
+        REQUIRE(front_ptr % alignof(ValueT) == 0);
+        REQUIRE(back_ptr % alignof(ValueT) == 0);
+        REQUIRE(back_ptr - front_ptr == sizeof(ValueT) * (vec.size() - 1u));
+    }
+}
+
+} // anonymous namespace
+
+TEMPLATE_TEST_CASE("SmallVector: Correct alignment after push_back() and shrink_to_fit()",
+    "[SmallVector]", char, short, double, std::string, OverAligned)
+{
+    test_alignment_with<SmallVector<TestType, 0>>();
+    test_alignment_with<SmallVector<TestType, 1>>();
+    test_alignment_with<SmallVector<TestType, 2>>();
+    test_alignment_with<SmallVector<TestType, 3>>();
+    test_alignment_with<SmallVector<TestType, 4>>();
+}
+
 
 //
 // Tests for indiviual member functions (in alphabetical order)


### PR DESCRIPTION
### [why]
`std::aligned_storage` is deprecated since C++23, see: https://stackoverflow.com/questions/71828288/why-is-stdaligned-storage-to-be-deprecated-in-c23-and-what-to-use-instead
    
### [how]
Use `alignas()` for the internal buffer and specify the alignment explicitly when calling `new` for an allocated buffer. As it turns out, an aligned `new[]` has to be deallocated with an aligned `delete[]`, so we have to change that handling, too. We also had no unit test for the alignment requirements, so we add one.