### PR TITLE
Feature/build on older macos

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -54,6 +54,9 @@ endif
 if meson.get_compiler('cpp').has_argument('-Wnrvo') # msvc: included in permissive-
     add_cpp_args += [ '-Wnrvo' ]
 endif
+if meson.get_compiler('cpp').has_argument('-faligned-allocation') # Apple clang
+    add_cpp_args += [ '-faligned-allocation' ]
+endif
 
 deps = dependency('threads')
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -45,18 +45,9 @@ add_cpp_args = [ ]
 if build_machine.system() == 'darwin'
     add_cpp_args += [ '-U_LIBCPP_ENABLE_ASSERTIONS' ]
 endif
-if meson.get_compiler('cpp').has_argument('-Wshadow') # msvc doesnt have
-    add_cpp_args += [ '-Wshadow' ]
-endif
-if meson.get_compiler('cpp').has_argument('-Wconversion') # msvc doesnt have
-    add_cpp_args += [ '-Wconversion' ]
-endif
-if meson.get_compiler('cpp').has_argument('-Wnrvo') # msvc: included in permissive-
-    add_cpp_args += [ '-Wnrvo' ]
-endif
-if meson.get_compiler('cpp').has_argument('-faligned-allocation') # Apple clang
-    add_cpp_args += [ '-faligned-allocation' ]
-endif
+
+add_cpp_args += meson.get_compiler('cpp').get_supported_arguments(
+    [ '-Wshadow', '-Wconversion', '-Wnrvo', '-faligned-allocation' ])
 
 deps = dependency('threads')
 


### PR DESCRIPTION
See
* https://github.com/gul-cpp/gul17/pull/47#issuecomment-4599791255

## meson: Allow SmallVector to compile on all Macs

**[why]**
Building on Apple often involves setting the target MacOS version
Independent of compiler etc. This is done with clang's `-mmacosx-version-min`
command line flag.

Typically this is set to 10.9, as Apple switch from libstdc++ to libc++
with 10.9.

With MacOS prior to 10.13 we need to enable the aligned allocation, with the
switch `-faligned-allocation`:
"Enable C++17 aligned allocation functions"

With MacOS 10.13 and later the `-faligned-allocation` became standard,
but it does not hurt to insist on it as some projects might have turned
it off via `-fno-aligned-allocation`.

This commit is driven by the need to build GUL via conda-build which
targets all MacOS 10.9+.

10.9 (Mavericks, 2013) Minimum version we want to support
10.13 (High Sierra, 2017) Minimum version that has C++17 allocators

**[how]**
As we rely on these now, enable them if we can.
 